### PR TITLE
test: springboot test가 아닌, 더 가볍게 테스트 가능하도록 수정, chore: application-sample.yml 오탈자 수정

### DIFF
--- a/src/main/resources/application-sample.yml
+++ b/src/main/resources/application-sample.yml
@@ -12,7 +12,7 @@ spring:
 # redis setting
   data:
     redis:
-      host: localhost
+      host:
       port: 6379
 
 # hibernate setting
@@ -22,7 +22,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        format_sql: tru
+        format_sql: true
 
 # servlet setting
   servlet:

--- a/src/test/java/com/zerobase/babdeusilbun/component/ImageComponentTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/component/ImageComponentTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
@@ -19,20 +20,21 @@ import java.net.URL;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class ImageComponentTest {
-  @MockBean
+  @Mock
   private AmazonS3 amazonS3;
 
-  @Autowired
+  @InjectMocks
   private ImageComponent imageComponent;
 
   @Value("${cloud.aws.s3.bucketName}")
@@ -48,9 +50,9 @@ public class ImageComponentTest {
     FileInputStream fileInputStream = new FileInputStream("src/test/resources/img/symbol.png");
     MultipartFile multipartFile =
         new MockMultipartFile("file", filename, "image/png", fileInputStream);
-
     URL fakeUrl = URI.create(format("https://s3.amazonaws.com/%s/%s/%s", bucketName, folder, filename)).toURL();
-    given(amazonS3.getUrl(anyString(), anyString())).willReturn(fakeUrl);
+
+    given(amazonS3.getUrl(eq(bucketName), anyString())).willReturn(fakeUrl);
 
     //when
     List<String> urlList = imageComponent.uploadImageList(List.of(multipartFile), folder);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
  - 테스트 관련
    - SpringBootTest를 이용하여 SpringBootApplication을 찾아 Bean을 전체 생성해야 했기에 S3과 연동이 되고, 업로드 작업 과정이 실행되는가 확인하는 가벼운 테스트의 목적에 맞지 않게 한 번 실행할 때마다 모든 설정을 다 실행 시간이 길었습니다.
    - 테스트를 실행시키며 랜덤 변동값 뿐 아니라 고정되어 들어가는 값도 anyString()을 이용하여 신뢰도가 떨어졌습니다.
  - application-sample.yml 관련
    - 이용자가 입력해야하는 redis의 host 값이 채워져 있었습니다.
    - true가 오탈자인 tru로 작성되어 올라갔습니다.

**TO-BE**
  - 테스트 관련
    - @SpringBootTest 대신 @ExtendWith(MockitoExtension.class)를 사용하여, MockBean으로 자동주입시키는 게 아닌 Mock 객체를 생성하여 필요한 부분만 바꿔넣어 실행될 수 있게 했습니다.
    - 고정값은 정확한 값을 입력하여 테스트의 신뢰도를 높였습니다.
  - application-sample.yml 관련
    - redis의 host값을 지웠습니다.
    - true로 오탈자를 수정하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [ ] API 테스트 