### PR TITLE
refactor: MeetingRepository 쿼리 변경

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
@@ -2,28 +2,22 @@ package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Meeting;
 import com.zerobase.babdeusilbun.domain.User;
-import java.awt.print.Pageable;
 import java.util.List;
-import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
+  @Query("select m from meeting m "
+      + "where m.leader = :leader "
+      + "and m.status != 'MEETING_CANCELLED' and m.status != 'MEETING_COMPLETED' ")
+  List<Meeting> findProceedingByLeader(User leader);
 
-  @Query( "select m from meeting m "
-          + "where m.leader = :user "
-          + "and m.status != 'MEETING_CANCELLED' and m.status != 'MEETING_COMPLETED' "
-      + "union "
-        + "select m from purchase p "
-          + "join p.meeting m "
-          + "where p.user = :user "
-          + "and m.status != 'MEETING_CANCELLED' and m.status != 'MEETING_COMPLETED' ")
-  List<Meeting> findProceedingByUser(User user);
+  @Query("select m from meeting m "
+      + "join purchase p on p.meeting = m "
+      + "where p.user = :user "
+      + "and m.status != 'MEETING_CANCELLED' and m.status != 'MEETING_COMPLETED' ")
+  List<Meeting> findProceedingByParticipant(User participant);
 
-//  @Query("select m "
-//      + "from meeting m "
-//      + "join m.store st join store_school sc "
-//      + "where sc.store = st and sc.store.id = :storeId")
-//  Page<Meeting> findAllMeeting(Long storeId, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
@@ -259,8 +259,9 @@ public class SignServiceImpl implements SignService {
   }
 
   private void verifyProceedingMeeting(User findUser) {
-    List<Meeting> proceedingMeeting = meetingRepository.findProceedingByUser(findUser);
-    if (!proceedingMeeting.isEmpty()) {
+    List<Meeting> leaderMeetings = meetingRepository.findProceedingByLeader(findUser);
+    List<Meeting> userMeetings = meetingRepository.findProceedingByParticipant(findUser);
+    if (!leaderMeetings.isEmpty() || !userMeetings.isEmpty()) {
       throw new CustomException(USER_MEETING_STILL_LEFT);
     }
   }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
MeetingRepository에서 모임장이 개설한 모임과 유저가 참여한 모임을 동시에 가져오려고 하다 보니 쿼리 상에서 불필요한 복잡성이 올라갔습니다.

**TO-BE**
쿼리를 두개로 분리하고 각각 판별하는 방식으로 변경하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 