### PR TITLE
feature: 동일 학교 캠퍼스 검색 기능 개발

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/SchoolController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/SchoolController.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,5 +26,24 @@ public class SchoolController {
       @RequestParam(name = "page", required = false, defaultValue = "0") int page,
       @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
     return ResponseEntity.ok(schoolService.searchSchoolAndCampus(schoolName, page, size));
+  }
+
+
+  /**
+   * 캠퍼스 검색(입력값에 schoolId가 있는 경우 해당 id 기준, 없는 경우 로그인한 이용자 기준)
+   */
+  @PreAuthorize("hasRole('USER')")
+  @GetMapping("/campus")
+  public ResponseEntity<?> searchCampusBySchool(
+      @AuthenticationPrincipal UserCustomUserDetails user,
+      @RequestParam(name = "schoolId", required = false, defaultValue = "") Long schoolId,
+      @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+      @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+
+    if (schoolId == null || schoolId == 0L) {
+      schoolId = user.getSchoolId();
+    }
+
+    return ResponseEntity.ok(schoolService.searchCampusBySchool(schoolId, page, size));
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreImageDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreImageDto.java
@@ -1,0 +1,26 @@
+package com.zerobase.babdeusilbun.dto;
+
+import com.zerobase.babdeusilbun.domain.StoreImage;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class StoreImageDto {
+
+  private Long imageId;
+  private String url;
+
+  public static StoreImageDto fromEntity(StoreImage storeImage) {
+    return StoreImageDto.builder()
+        .imageId(storeImage.getId())
+        .url(storeImage.getUrl())
+        .build();
+  }
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package com.zerobase.babdeusilbun.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.Getter;
@@ -10,13 +11,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-  SCHOOL_NOT_FOUND(BAD_REQUEST, "couldn't find school"),
+  SCHOOL_NOT_FOUND(NOT_FOUND, "couldn't find school"),
 
-  MAJOR_NOT_FOUND(BAD_REQUEST, "couldn't find major"),
+  MAJOR_NOT_FOUND(NOT_FOUND, "couldn't find major"),
 
-  USER_NOT_FOUND(BAD_REQUEST, "couldn't find user"),
+  USER_NOT_FOUND(NOT_FOUND, "couldn't find user"),
 
-  ENTREPRENEUR_NOT_FOUND(BAD_REQUEST, "couldn't find entrepreneur"),
+  ENTREPRENEUR_NOT_FOUND(NOT_FOUND, "couldn't find entrepreneur"),
 
   PARAMETER_INVALID(BAD_REQUEST, "this is wrong parameter"),
 
@@ -48,17 +49,17 @@ public enum ErrorCode {
       "the number of images requested to upload exceeds the maximum allowed number."),
 
   // 모임 관련
-  MEETING_NOT_FOUND(BAD_REQUEST, "couldn't find meeting"),
+  MEETING_NOT_FOUND(NOT_FOUND, "couldn't find meeting"),
   MEETING_STATUS_INVALID(BAD_REQUEST, "meeting status is invalid"),
   MEETING_LEADER_NOT_MATCH(BAD_REQUEST, "this user is not a leader of that meeting"),
   MEETING_PARTICIPANT_EXIST(BAD_REQUEST, "this meeting have participants"),
 
   // 주문 관련
-  PURCHASE_NOT_FOUND(BAD_REQUEST, "couldn't find purchase"),
-  PURCHASE_PAYMENT_NOT_FOUND(BAD_REQUEST, "couldn't find purchase snapshot"),
+  PURCHASE_NOT_FOUND(NOT_FOUND, "couldn't find purchase"),
+  PURCHASE_PAYMENT_NOT_FOUND(NOT_FOUND, "couldn't find purchase snapshot"),
 
   // 상점 관련
-  STORE_NOT_FOUND(BAD_REQUEST, "couldn't find store"),
+  STORE_NOT_FOUND(NOT_FOUND, "couldn't find store"),
 
   //이메일 인증 관련
   CANNOT_SEND_MAIL_EXCEEDS_MAX_COUNT(BAD_REQUEST,

--- a/src/main/java/com/zerobase/babdeusilbun/repository/MeetingQueryRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MeetingQueryRepository.java
@@ -53,7 +53,7 @@ public class MeetingQueryRepository {
     }
 
     if (categoryFilter != null) {
-
+      list.add(categoryExpression(categoryFilter));
     }
 
     return list.toArray(new BooleanExpression[0]);

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomSchoolRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomSchoolRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.domain.Page;
 
 public interface CustomSchoolRepository {
   Page<Information> searchSchoolNameByKeywords(String[] keywords, int page, int size);
+  Page<Information> searchCampusBySchool(Information standard, int page, int size);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/security/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/config/SecurityConfig.java
@@ -44,9 +44,9 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
     List<String> permitAllUrls = Arrays.asList(
-        "/", "/api/signin", "/api/user/signup/**", "/api/business/signup/**", "/h2-console/**",
+        "/", "/api/signin", "/api/users/sign**", "/api/businesses/sign**", "/h2-console/**",
         "/swagger-ui/**", "/swagger-ui-custom.html", "/v3/api-docs/**",
-        "/api/signup/**"
+        "/api/sign**"
     );
 
     http

--- a/src/main/java/com/zerobase/babdeusilbun/security/dto/UserCustomUserDetails.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/dto/UserCustomUserDetails.java
@@ -22,6 +22,10 @@ public class UserCustomUserDetails implements UserDetails {
     return List.of(new SimpleGrantedAuthority(ROLE_USER.name()));
   }
 
+  public Long getSchoolId() {
+    return user.getSchool().getId();
+  }
+
   @Override
   public String getPassword() {
     return user.getPassword();

--- a/src/main/java/com/zerobase/babdeusilbun/service/SchoolService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/SchoolService.java
@@ -5,4 +5,6 @@ import org.springframework.data.domain.Page;
 
 public interface SchoolService {
   Page<Information> searchSchoolAndCampus(String schoolName, int page, int size);
+
+  Page<Information> searchCampusBySchool(Long schoolId, int page, int size);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/SchoolServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/SchoolServiceImpl.java
@@ -1,6 +1,8 @@
 package com.zerobase.babdeusilbun.service.impl;
 
 import com.zerobase.babdeusilbun.dto.SchoolDto.Information;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.exception.ErrorCode;
 import com.zerobase.babdeusilbun.repository.SchoolRepository;
 import com.zerobase.babdeusilbun.service.SchoolService;
 import lombok.AllArgsConstructor;
@@ -17,5 +19,15 @@ public class SchoolServiceImpl implements SchoolService {
   @Transactional(readOnly = true)
   public Page<Information> searchSchoolAndCampus(String schoolName, int page, int size) {
     return schoolRepository.searchSchoolNameByKeywords(schoolName.split(" +"), page, size);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Page<Information> searchCampusBySchool(Long schoolId, int page, int size) {
+    Information standard = Information.fromEntity(
+        schoolRepository.findById(schoolId).orElseThrow(() -> new CustomException(ErrorCode.SCHOOL_NOT_FOUND))
+    );
+
+    return schoolRepository.searchCampusBySchool(standard, page, size);
   }
 }

--- a/src/test/java/com/zerobase/babdeusilbun/controller/SchoolControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/SchoolControllerTest.java
@@ -10,8 +10,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.zerobase.babdeusilbun.dto.SchoolDto.Information;
+import com.zerobase.babdeusilbun.security.dto.UserCustomUserDetails;
 import com.zerobase.babdeusilbun.service.SchoolService;
+import com.zerobase.babdeusilbun.util.TestUserUtility;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +23,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -30,6 +35,16 @@ class SchoolControllerTest {
 
   @MockBean
   private SchoolService schoolService;
+
+  @BeforeEach
+  void setUp() {
+    //로그인 정보 세팅
+    UserCustomUserDetails userDetails = TestUserUtility.createTestUser();
+
+    SecurityContextHolder.getContext().setAuthentication(
+        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+    );
+  }
 
   @DisplayName("학교 검색 테스트")
   @WithMockUser
@@ -50,6 +65,58 @@ class SchoolControllerTest {
             .param("size", "10")
             .contentType(MediaType.APPLICATION_JSON)
             .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].name").value("가짜 학교"))
+        .andExpect(jsonPath("$.totalElements").value(1))
+        .andExpect(jsonPath("$.pageable").exists());
+  }
+
+  @DisplayName("캠퍼스 검색 테스트(schoolId에 값을 입력했을 경우)")
+  @Test
+  void searchCampusBySchoolWithSchoolId() throws Exception {
+    //given
+    Information info = new Information(2L, "가짜 학교", "가짜 캠퍼스");
+    Page<Information> expectedPage = new PageImpl<>(List.of(info));
+
+    //when
+    when(schoolService.searchCampusBySchool(2L, 0, 10))
+        .thenReturn(expectedPage);
+
+    //then
+    mockMvc.perform(get("/api/campus")
+            .param("schoolId", "2")
+            .param("page", "0")
+            .param("size", "10")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].name").value("가짜 학교"))
+        .andExpect(jsonPath("$.totalElements").value(1))
+        .andExpect(jsonPath("$.pageable").exists());
+  }
+
+  @DisplayName("캠퍼스 검색 테스트(schoolId에 값이 없을 경우)")
+  @Test
+  void searchCampusBySchoolWithUserInfo() throws Exception {
+    //given
+    Information info = new Information(1L, "가짜 학교", "가짜 캠퍼스");
+    Page<Information> expectedPage = new PageImpl<>(List.of(info));
+
+    //when
+    when(schoolService.searchCampusBySchool(1L, 0, 10))
+        .thenReturn(expectedPage);
+
+    //then
+    mockMvc.perform(get("/api/campus")
+            .param("schoolId", "")
+            .param("page", "0")
+            .param("size", "10")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.content").isArray())

--- a/src/test/java/com/zerobase/babdeusilbun/service/SchoolServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/SchoolServiceTest.java
@@ -1,12 +1,17 @@
 package com.zerobase.babdeusilbun.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import com.zerobase.babdeusilbun.domain.School;
 import com.zerobase.babdeusilbun.dto.SchoolDto.Information;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.exception.ErrorCode;
 import com.zerobase.babdeusilbun.repository.SchoolRepository;
 import com.zerobase.babdeusilbun.service.impl.SchoolServiceImpl;
 import java.util.Collections;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,5 +45,47 @@ public class SchoolServiceTest {
 
     //then
     assertEquals(expectedPage, result);
+  }
+
+  @DisplayName("캠퍼스 검색 서비스 성공 사례 테스트")
+  @Test
+  void searchCampusBySchoolSuccess() {
+    //given
+    Long schoolId = 1L;
+    Information info = new Information(1L, "가짜 학교", "가짜 캠퍼스");
+
+    School school = School.builder()
+        .id(schoolId)
+        .name(info.getName())
+        .campus(info.getCampus())
+        .build();
+
+    Page<Information> expectedPage = new PageImpl<>(Collections.singletonList(info));
+
+    //when
+    when(schoolRepository.findById(schoolId)).thenReturn(Optional.ofNullable(school));
+    when(schoolRepository.searchCampusBySchool(info, 0, 10)).thenReturn(expectedPage);
+
+    Page<Information> result = schoolService.searchCampusBySchool(schoolId, 0, 10);
+
+    //then
+    assertEquals(expectedPage, result);
+  }
+
+  @DisplayName("캠퍼스 검색 서비스 실패 사례 테스트")
+  @Test
+  void searchCampusBySchoolFailed() {
+    //given
+    Long schoolId = 1L;
+
+    //when
+    when(schoolRepository.findById(schoolId)).thenReturn(Optional.empty());
+
+    //then
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      schoolService.searchCampusBySchool(schoolId, 0, 10);
+    });
+
+    assertEquals(ErrorCode.SCHOOL_NOT_FOUND, exception.getErrorCode());
   }
 }

--- a/src/test/java/com/zerobase/babdeusilbun/util/TestUserUtility.java
+++ b/src/test/java/com/zerobase/babdeusilbun/util/TestUserUtility.java
@@ -1,0 +1,24 @@
+package com.zerobase.babdeusilbun.util;
+
+import com.zerobase.babdeusilbun.domain.School;
+import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.security.dto.UserCustomUserDetails;
+
+public class TestUserUtility {
+  public static UserCustomUserDetails createTestUser() {
+    School school = School.builder()
+        .id(1L)
+        .name("가짜 학교")
+        .campus("가짜캠퍼스")
+        .build();
+
+    User user = User.builder()
+        .id(1L)
+        .email("test@test.com")
+        .password("password")
+        .school(school)
+        .build();
+
+    return new UserCustomUserDetails(user);
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
  - 로그인한 사용자에게서 school객체, 혹은 schoolId를 가져올 수 있어야 했는데 관련 get 함수가 없었습니다.
  - SecurityConfig에서 url이 복수형인데 단수형으로 작성되어있는 경우가 있었습니다.
  - SecurityConfig에서 로그인 없이 이용가능한 api가 signup 혹은 signin으로 묶인 url만 가능하여 정작 세부로 나뉘지 않은 url은 이용할 수 없었습니다.
  - schoolId를 통해 같은 학교의 캠퍼스를 조회하는 기능이 필요했습니다.
  - 입력값은 제대로 있었으나 관련된 엔티티를 받아올 수 없을 때도 입력값이 잘못되었다는 상태코드를 반환했습니다.
  - schoolId를 통해 같은 학교의 캠퍼스를 조회하는 기능에 대한 테스트가 필요했습니다.

**TO-BE**
  - UserCustomUserDetails에 schoolId를 조회할 수 있는 함수를 생성했습니다.
  - SecurityConfig에서 url이 단수형으로 잘못 기재된 경우의 오탈자를 수정하였습니다.
  - SecurityConfig에서 세부로 나뉘지 않은 url도 이용 가능하게 범위를 확장하였습니다.
  - schoolId를 통해 같은 학교의 캠퍼스를 조회하는 기능을 구현했습니다.
    - controller
      - requestParam으로 입력된 schoolId가 있는 경우 입력된 schoolId를 기준으로 같은 학교의 전체 캠퍼스를 조회
      - requestParam으로 입력된 schoolId가 없는 경우 로그인한 사용자의 학교(캠퍼스)를 기준으로 같은 학교의 전체 캠퍼스를 조회
    - service
      - controller에서 전달받은 schoolId에 해당하는 school 엔티티의 Information 조회
      - Information을 기준으로 repository 호출
    - repository
      - 기준이 된 정보는 가장 위로 고정, 나머지는 학교명순, 캠퍼스순으로 정렬
      - 입력되었던 page와 size가 범위내에 없을 시 최대 size와 마지막page로 고정
  - ErrorCode에서 매칭된 엔티티가 없는 경우 NOT_FOUND로 HttpStatus 변경
  - 같은 학교의 캠퍼스를 조회하는 기능에 대한 테스트코드 작성

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
    <details>
      <summary>캠퍼스 검색 컨트롤러 테스트</summary>

      - BeforeEach를 통해 사전 로그인한 정보를 세팅
      - 과정
        - testUser에게 1L의 schoolId 부여
        - schoolId에 값을 입력했을 경우 schoolId에 2L의 값이 들어가야만 기대값 나오도록 설계
        - 값을 입력하지 않았을 경우 schoolId에 1L의 값이 들어가야만 기대값 나오도록 설계
        - 각 경우에 기댓값이 제대로 나오는 지 확인
        - 기댓값이 pageable 한지 확인
    </details>
    <details>
      <summary>캠퍼스 검색 서비스 성공 사례 테스트</summary>

      - 입력된 schoolId에 나올 school Entity 정보 확인
      - 기댓값으로 값이 나오는지 확인 
    </details>
    <details>
      <summary>캠퍼스 검색 서비스 실패 사례 테스트</summary>

      - 입력된 schoolId에 맞는 school 객체를 찾을 수 없는 것으로 설정
      - 커스텀한 에러가 나오는 지 확인
    </details>
- [x] API 테스트 