### PR TITLE
feature: 비밀번호 확인 기능 생성 및 구현, test: 비밀번호 확인 컨트롤러, 서비스 테스트

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/component/ImageComponent.java
+++ b/src/main/java/com/zerobase/babdeusilbun/component/ImageComponent.java
@@ -47,7 +47,7 @@ public class ImageComponent {
       try {
         successList.add(uploadImage(image, folder));
       } catch (Exception e) {
-        log.error("failed to upload storeImageDto. storeImageDto filename -> {} ", image.getOriginalFilename());
+        log.error("failed to upload image. image filename -> {} ", image.getOriginalFilename());
       }
     }
 
@@ -68,7 +68,7 @@ public class ImageComponent {
     byte[] bytes = IOUtils.toByteArray(stream);
 
     ObjectMetadata metadata = new ObjectMetadata();
-    metadata.setContentType(format("storeImageDto/%s", getExtension(fileName)));
+    metadata.setContentType(format("image/%s", getExtension(fileName)));
     metadata.setContentLength(bytes.length);
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
 

--- a/src/main/java/com/zerobase/babdeusilbun/controller/SchoolController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/SchoolController.java
@@ -1,5 +1,6 @@
 package com.zerobase.babdeusilbun.controller;
 
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.SchoolService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -34,15 +35,10 @@ public class SchoolController {
   @PreAuthorize("hasRole('USER')")
   @GetMapping("/campus")
   public ResponseEntity<?> searchCampusBySchool(
-      @AuthenticationPrincipal UserCustomUserDetails user,
+      @AuthenticationPrincipal CustomUserDetails user,
       @RequestParam(name = "schoolId", required = false, defaultValue = "") Long schoolId,
       @RequestParam(name = "page", required = false, defaultValue = "0") int page,
       @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
-
-    if (schoolId == null || schoolId == 0L) {
-      schoolId = user.getSchoolId();
-    }
-
-    return ResponseEntity.ok(schoolService.searchCampusBySchool(schoolId, page, size));
+    return ResponseEntity.ok(schoolService.searchCampusBySchool(user, schoolId, page, size));
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/SignDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/SignDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.babdeusilbun.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,5 +28,21 @@ public class SignDto {
   @NoArgsConstructor
   public static class VerifyCodeResponse {
     private boolean result;
+  }
+
+  @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class VerifyPasswordRequest {
+    private String password;
+  }
+
+  @Data
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class VerifyPasswordResponse {
+    @JsonProperty("isCorrected")
+    private boolean isCorrected;
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.zerobase.babdeusilbun.security.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
+import com.zerobase.babdeusilbun.dto.SignDto;
 import com.zerobase.babdeusilbun.security.application.AuthApplication;
 import com.zerobase.babdeusilbun.security.dto.EmailCheckDto;
 import com.zerobase.babdeusilbun.security.dto.RefreshTokenRequest;
@@ -13,6 +14,8 @@ import com.zerobase.babdeusilbun.security.service.JwtValidationService;
 import com.zerobase.babdeusilbun.security.service.SignService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,6 +31,17 @@ public class AuthController {
   private final SignService signService;
   private final JwtValidationService jwtValidationService;
   private final AuthApplication authApplication;
+
+  /**
+   * 비밀번호 확인
+   */
+  @PostMapping("/password-confirm")
+  public ResponseEntity<?> passwordConfirm(
+      @AuthenticationPrincipal UserDetails user,
+      @RequestBody SignDto.VerifyPasswordRequest request) {
+
+    return ResponseEntity.ok(signService.passwordConfirm(request, user.getPassword()));
+  }
 
   /**
    * 이메일 중복확인
@@ -129,5 +143,4 @@ public class AuthController {
 
     return ResponseEntity.status(CREATED).body(response);
   }
-
 }

--- a/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.OK;
 
 import com.zerobase.babdeusilbun.dto.SignDto;
 import com.zerobase.babdeusilbun.security.application.AuthApplication;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.security.dto.EmailCheckDto;
 import com.zerobase.babdeusilbun.security.dto.RefreshTokenRequest;
 import com.zerobase.babdeusilbun.security.dto.SignRequest;
@@ -15,7 +16,6 @@ import com.zerobase.babdeusilbun.security.service.SignService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,10 +37,10 @@ public class AuthController {
    */
   @PostMapping("/password-confirm")
   public ResponseEntity<?> passwordConfirm(
-      @AuthenticationPrincipal UserDetails user,
+      @AuthenticationPrincipal CustomUserDetails user,
       @RequestBody SignDto.VerifyPasswordRequest request) {
 
-    return ResponseEntity.ok(signService.passwordConfirm(request, user.getPassword()));
+    return ResponseEntity.ok(signService.passwordConfirm(request, user.getId()));
   }
 
   /**

--- a/src/main/java/com/zerobase/babdeusilbun/security/dto/CustomUserDetails.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/dto/CustomUserDetails.java
@@ -8,12 +8,13 @@ import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.security.type.Role;
 import java.util.Collection;
 import java.util.List;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 public class CustomUserDetails implements UserDetails {
-
+  @Getter
   private final Long id;
 
   private final String email;

--- a/src/main/java/com/zerobase/babdeusilbun/security/dto/UserCustomUserDetails.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/dto/UserCustomUserDetails.java
@@ -28,10 +28,6 @@ public class UserCustomUserDetails implements UserDetails {
     return List.of(new SimpleGrantedAuthority(role.name()));
   }
 
-  public Long getSchoolId() {
-    return user.getSchool().getId();
-  }
-
   @Override
   public String getPassword() {
     return null;

--- a/src/main/java/com/zerobase/babdeusilbun/security/service/SignService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/service/SignService.java
@@ -8,7 +8,7 @@ import com.zerobase.babdeusilbun.security.dto.SignRequest.UserSignUp;
 import com.zerobase.babdeusilbun.security.dto.WithdrawalRequest;
 
 public interface SignService {
-  VerifyPasswordResponse passwordConfirm(VerifyPasswordRequest request, String password);
+  VerifyPasswordResponse passwordConfirm(VerifyPasswordRequest request, Long userId);
 
   boolean isEmailIsUnique(String email);
 

--- a/src/main/java/com/zerobase/babdeusilbun/security/service/SignService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/service/SignService.java
@@ -1,11 +1,14 @@
 package com.zerobase.babdeusilbun.security.service;
 
+import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordRequest;
+import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordResponse;
 import com.zerobase.babdeusilbun.security.dto.SignRequest.BusinessSignUp;
 import com.zerobase.babdeusilbun.security.dto.SignRequest.SignIn;
 import com.zerobase.babdeusilbun.security.dto.SignRequest.UserSignUp;
 import com.zerobase.babdeusilbun.security.dto.WithdrawalRequest;
 
 public interface SignService {
+  VerifyPasswordResponse passwordConfirm(VerifyPasswordRequest request, String password);
 
   boolean isEmailIsUnique(String email);
 

--- a/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
@@ -22,6 +22,8 @@ import com.zerobase.babdeusilbun.domain.Meeting;
 import com.zerobase.babdeusilbun.domain.Purchase;
 import com.zerobase.babdeusilbun.domain.School;
 import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordRequest;
+import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordResponse;
 import com.zerobase.babdeusilbun.repository.EntrepreneurRepository;
 import com.zerobase.babdeusilbun.repository.MajorRepository;
 import com.zerobase.babdeusilbun.repository.MeetingRepository;
@@ -66,6 +68,13 @@ public class SignServiceImpl implements SignService {
 
   private final RedisTemplate<String, String> stringRedisTemplate;
   private final RedisTemplate<String, String> refreshTokenRedisTemplate;
+
+  @Override
+  public VerifyPasswordResponse passwordConfirm(VerifyPasswordRequest request, String password) {
+    return VerifyPasswordResponse.builder()
+        .isCorrected(passwordEncoder.matches(request.getPassword(), password))
+        .build();
+  }
 
   /**
    * 이메일 중복 확인

--- a/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
@@ -70,9 +70,12 @@ public class SignServiceImpl implements SignService {
   private final RedisTemplate<String, String> refreshTokenRedisTemplate;
 
   @Override
-  public VerifyPasswordResponse passwordConfirm(VerifyPasswordRequest request, String password) {
+  @Transactional(readOnly = true)
+  public VerifyPasswordResponse passwordConfirm(VerifyPasswordRequest request, Long userId) {
+    User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
     return VerifyPasswordResponse.builder()
-        .isCorrected(passwordEncoder.matches(request.getPassword(), password))
+        .isCorrected(passwordEncoder.matches(request.getPassword(), user.getPassword()))
         .build();
   }
 

--- a/src/main/java/com/zerobase/babdeusilbun/service/SchoolService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/SchoolService.java
@@ -1,10 +1,11 @@
 package com.zerobase.babdeusilbun.service;
 
 import com.zerobase.babdeusilbun.dto.SchoolDto.Information;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import org.springframework.data.domain.Page;
 
 public interface SchoolService {
   Page<Information> searchSchoolAndCampus(String schoolName, int page, int size);
 
-  Page<Information> searchCampusBySchool(Long schoolId, int page, int size);
+  Page<Information> searchCampusBySchool(CustomUserDetails user, Long schoolId, int page, int size);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/SchoolServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/SchoolServiceImpl.java
@@ -4,6 +4,8 @@ import com.zerobase.babdeusilbun.dto.SchoolDto.Information;
 import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.exception.ErrorCode;
 import com.zerobase.babdeusilbun.repository.SchoolRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.SchoolService;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @AllArgsConstructor
 public class SchoolServiceImpl implements SchoolService {
   private final SchoolRepository schoolRepository;
+  private final UserRepository userRepository;
 
   @Override
   @Transactional(readOnly = true)
@@ -23,7 +26,13 @@ public class SchoolServiceImpl implements SchoolService {
 
   @Override
   @Transactional(readOnly = true)
-  public Page<Information> searchCampusBySchool(Long schoolId, int page, int size) {
+  public Page<Information> searchCampusBySchool(CustomUserDetails user, Long schoolId, int page, int size) {
+    if (schoolId == null || schoolId == 0L) {
+      schoolId = userRepository.findById(user.getId())
+          .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND))
+          .getSchool().getId();
+    }
+
     Information standard = Information.fromEntity(
         schoolRepository.findById(schoolId).orElseThrow(() -> new CustomException(ErrorCode.SCHOOL_NOT_FOUND))
     );

--- a/src/test/java/com/zerobase/babdeusilbun/controller/AuthControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/AuthControllerTest.java
@@ -1,0 +1,76 @@
+package com.zerobase.babdeusilbun.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordRequest;
+import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordResponse;
+import com.zerobase.babdeusilbun.security.application.AuthApplication;
+import com.zerobase.babdeusilbun.security.controller.AuthController;
+import com.zerobase.babdeusilbun.security.dto.UserCustomUserDetails;
+import com.zerobase.babdeusilbun.security.service.JwtValidationService;
+import com.zerobase.babdeusilbun.security.service.impl.SignServiceImpl;
+import com.zerobase.babdeusilbun.util.TestUserUtility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+public class AuthControllerTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private SignServiceImpl signService;
+  @MockBean
+  private JwtValidationService jwtValidationService;
+  @MockBean
+  private AuthApplication authApplication;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    //로그인 정보 세팅
+    UserCustomUserDetails userDetails = TestUserUtility.createTestUser();
+
+    SecurityContextHolder.getContext().setAuthentication(
+        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+    );
+  }
+
+  @DisplayName("비밀번호 확인 테스트")
+  @Test
+  void passwordConfirm() throws Exception {
+    //given
+    VerifyPasswordRequest request = new VerifyPasswordRequest("password");
+    VerifyPasswordResponse response = VerifyPasswordResponse.builder().isCorrected(true).build();
+
+    //when
+    when(signService.passwordConfirm(eq(request), anyString())).thenReturn(response);
+
+    //then
+    mockMvc.perform(post("/api/password-confirm")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.isCorrected").value(true));
+  }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/controller/AuthControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/AuthControllerTest.java
@@ -1,6 +1,5 @@
 package com.zerobase.babdeusilbun.controller;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -14,7 +13,7 @@ import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordRequest;
 import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordResponse;
 import com.zerobase.babdeusilbun.security.application.AuthApplication;
 import com.zerobase.babdeusilbun.security.controller.AuthController;
-import com.zerobase.babdeusilbun.security.dto.UserCustomUserDetails;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.security.service.JwtValidationService;
 import com.zerobase.babdeusilbun.security.service.impl.SignServiceImpl;
 import com.zerobase.babdeusilbun.util.TestUserUtility;
@@ -44,13 +43,15 @@ public class AuthControllerTest {
   @Autowired
   private ObjectMapper objectMapper;
 
+  private CustomUserDetails testUser;
+
   @BeforeEach
   void setUp() {
     //로그인 정보 세팅
-    UserCustomUserDetails userDetails = TestUserUtility.createTestUser();
+    testUser = TestUserUtility.createTestUser();
 
     SecurityContextHolder.getContext().setAuthentication(
-        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+        new UsernamePasswordAuthenticationToken(testUser, null, testUser.getAuthorities())
     );
   }
 
@@ -62,7 +63,7 @@ public class AuthControllerTest {
     VerifyPasswordResponse response = VerifyPasswordResponse.builder().isCorrected(true).build();
 
     //when
-    when(signService.passwordConfirm(eq(request), anyString())).thenReturn(response);
+    when(signService.passwordConfirm(eq(request), eq(testUser.getId()))).thenReturn(response);
 
     //then
     mockMvc.perform(post("/api/password-confirm")

--- a/src/test/java/com/zerobase/babdeusilbun/controller/SchoolControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/SchoolControllerTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.zerobase.babdeusilbun.dto.SchoolDto.Information;
-import com.zerobase.babdeusilbun.security.dto.UserCustomUserDetails;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.SchoolService;
 import com.zerobase.babdeusilbun.util.TestUserUtility;
 import java.util.List;
@@ -36,13 +36,15 @@ class SchoolControllerTest {
   @MockBean
   private SchoolService schoolService;
 
+  private CustomUserDetails testUser;
+
   @BeforeEach
   void setUp() {
     //로그인 정보 세팅
-    UserCustomUserDetails userDetails = TestUserUtility.createTestUser();
+    testUser = TestUserUtility.createTestUser();
 
     SecurityContextHolder.getContext().setAuthentication(
-        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+        new UsernamePasswordAuthenticationToken(testUser, null, testUser.getAuthorities())
     );
   }
 
@@ -81,7 +83,7 @@ class SchoolControllerTest {
     Page<Information> expectedPage = new PageImpl<>(List.of(info));
 
     //when
-    when(schoolService.searchCampusBySchool(2L, 0, 10))
+    when(schoolService.searchCampusBySchool(testUser, 2L, 0, 10))
         .thenReturn(expectedPage);
 
     //then
@@ -107,7 +109,7 @@ class SchoolControllerTest {
     Page<Information> expectedPage = new PageImpl<>(List.of(info));
 
     //when
-    when(schoolService.searchCampusBySchool(1L, 0, 10))
+    when(schoolService.searchCampusBySchool(testUser, null, 0, 10))
         .thenReturn(expectedPage);
 
     //then

--- a/src/test/java/com/zerobase/babdeusilbun/service/SchoolServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/SchoolServiceTest.java
@@ -5,11 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.zerobase.babdeusilbun.domain.School;
+import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.dto.SchoolDto.Information;
 import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.exception.ErrorCode;
 import com.zerobase.babdeusilbun.repository.SchoolRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.impl.SchoolServiceImpl;
+import com.zerobase.babdeusilbun.util.TestUserUtility;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -26,8 +30,13 @@ public class SchoolServiceTest {
   @Mock
   private SchoolRepository schoolRepository;
 
+  @Mock
+  private UserRepository userRepository;
+
   @InjectMocks
   private SchoolServiceImpl schoolService;
+
+  private final CustomUserDetails testUser = TestUserUtility.createTestUser();
 
   @DisplayName("학교 검색 서비스 테스트")
   @Test
@@ -66,26 +75,73 @@ public class SchoolServiceTest {
     when(schoolRepository.findById(schoolId)).thenReturn(Optional.ofNullable(school));
     when(schoolRepository.searchCampusBySchool(info, 0, 10)).thenReturn(expectedPage);
 
-    Page<Information> result = schoolService.searchCampusBySchool(schoolId, 0, 10);
+    Page<Information> result = schoolService.searchCampusBySchool(testUser, schoolId, 0, 10);
 
     //then
     assertEquals(expectedPage, result);
   }
 
-  @DisplayName("캠퍼스 검색 서비스 실패 사례 테스트")
+  @DisplayName("캠퍼스 검색 서비스 성공 사례 테스트(schoolId 제공되지 않은 경우)")
   @Test
-  void searchCampusBySchoolFailed() {
-    //given
+  void searchCampusBySchoolWithoutSchoolIdSuccess() {
+    // given
     Long schoolId = 1L;
+    CustomUserDetails userDetails = TestUserUtility.createTestUser();
+    User user = TestUserUtility.getUser();
 
-    //when
+    Information info = new Information(schoolId, "가짜 학교", "가짜 캠퍼스");
+
+    School school = School.builder()
+        .id(schoolId)
+        .name(info.getName())
+        .campus(info.getCampus())
+        .build();
+
+    Page<Information> expectedPage = new PageImpl<>(Collections.singletonList(info));
+
+    // when
+    when(userRepository.findById(userDetails.getId())).thenReturn(Optional.of(user));
+    when(schoolRepository.findById(schoolId)).thenReturn(Optional.of(school));
+    when(schoolRepository.searchCampusBySchool(info, 0, 10)).thenReturn(expectedPage);
+
+    Page<Information> result = schoolService.searchCampusBySchool(userDetails, null, 0, 10);
+
+    // then
+    assertEquals(expectedPage, result);
+  }
+
+  @DisplayName("캠퍼스 검색 서비스 실패 사례 테스트(학교 정보가 없을 때)")
+  @Test
+  void searchCampusBySchoolFailedWhenSchoolNotFound() {
+    // given
+    Long schoolId = 1L;
+    CustomUserDetails user = TestUserUtility.createTestUser();
+
+    // when
     when(schoolRepository.findById(schoolId)).thenReturn(Optional.empty());
 
-    //then
+    // then
     CustomException exception = assertThrows(CustomException.class, () -> {
-      schoolService.searchCampusBySchool(schoolId, 0, 10);
+      schoolService.searchCampusBySchool(user, schoolId, 0, 10);
     });
 
     assertEquals(ErrorCode.SCHOOL_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @DisplayName("캠퍼스 검색 서비스 실패 사례 테스트(사용자 정보가 없을 때)")
+  @Test
+  void searchCampusBySchoolFailedWhenUserNotFound() {
+    // given
+    CustomUserDetails user = TestUserUtility.createTestUser();
+
+    // when
+    when(userRepository.findById(user.getId())).thenReturn(Optional.empty());
+
+    // then
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      schoolService.searchCampusBySchool(user, null, 0, 10);
+    });
+
+    assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
   }
 }

--- a/src/test/java/com/zerobase/babdeusilbun/service/SignServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/SignServiceTest.java
@@ -4,9 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordRequest;
 import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordResponse;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.security.service.impl.SignServiceImpl;
+import com.zerobase.babdeusilbun.util.TestUserUtility;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +25,9 @@ public class SignServiceTest {
   @Mock
   private PasswordEncoder passwordEncoder;
 
+  @Mock
+  private UserRepository userRepository;
+
   @InjectMocks
   private SignServiceImpl signService;
 
@@ -28,13 +36,15 @@ public class SignServiceTest {
   void passwordConfirmSuccess() {
     // given
     String rawPassword = "testPassword";
-    String encodedPassword = "encodedPassword";
     VerifyPasswordRequest request = new VerifyPasswordRequest(rawPassword);
+    CustomUserDetails userDetails = TestUserUtility.createTestUser();
+    User user = TestUserUtility.getUser();
 
     // when
-    when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+    when(userRepository.findById(userDetails.getId())).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(rawPassword, user.getPassword())).thenReturn(true);
 
-    VerifyPasswordResponse response = signService.passwordConfirm(request, encodedPassword);
+    VerifyPasswordResponse response = signService.passwordConfirm(request, userDetails.getId());
 
     // then
     assertTrue(response.isCorrected());
@@ -45,13 +55,15 @@ public class SignServiceTest {
   void passwordConfirmFailed() {
     // given
     String rawPassword = "testPassword";
-    String encodedPassword = "encodedPassword";
     VerifyPasswordRequest request = new VerifyPasswordRequest(rawPassword);
+    CustomUserDetails userDetails = TestUserUtility.createTestUser();
+    User user = TestUserUtility.getUser();
 
     // when
-    when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(false);
+    when(userRepository.findById(userDetails.getId())).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(rawPassword, user.getPassword())).thenReturn(false);
 
-    VerifyPasswordResponse response = signService.passwordConfirm(request, encodedPassword);
+    VerifyPasswordResponse response = signService.passwordConfirm(request, userDetails.getId());
 
     // then
     assertFalse(response.isCorrected());

--- a/src/test/java/com/zerobase/babdeusilbun/service/SignServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/SignServiceTest.java
@@ -1,0 +1,59 @@
+package com.zerobase.babdeusilbun.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordRequest;
+import com.zerobase.babdeusilbun.dto.SignDto.VerifyPasswordResponse;
+import com.zerobase.babdeusilbun.security.service.impl.SignServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class SignServiceTest {
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @InjectMocks
+  private SignServiceImpl signService;
+
+  @DisplayName("비밀번호 확인 성공 테스트")
+  @Test
+  void passwordConfirmSuccess() {
+    // given
+    String rawPassword = "testPassword";
+    String encodedPassword = "encodedPassword";
+    VerifyPasswordRequest request = new VerifyPasswordRequest(rawPassword);
+
+    // when
+    when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+
+    VerifyPasswordResponse response = signService.passwordConfirm(request, encodedPassword);
+
+    // then
+    assertTrue(response.isCorrected());
+  }
+
+  @DisplayName("비밀번호 확인 실패 테스트")
+  @Test
+  void passwordConfirmFailed() {
+    // given
+    String rawPassword = "testPassword";
+    String encodedPassword = "encodedPassword";
+    VerifyPasswordRequest request = new VerifyPasswordRequest(rawPassword);
+
+    // when
+    when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(false);
+
+    VerifyPasswordResponse response = signService.passwordConfirm(request, encodedPassword);
+
+    // then
+    assertFalse(response.isCorrected());
+  }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/util/TestUserUtility.java
+++ b/src/test/java/com/zerobase/babdeusilbun/util/TestUserUtility.java
@@ -2,23 +2,26 @@ package com.zerobase.babdeusilbun.util;
 
 import com.zerobase.babdeusilbun.domain.School;
 import com.zerobase.babdeusilbun.domain.User;
-import com.zerobase.babdeusilbun.security.dto.UserCustomUserDetails;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 
 public class TestUserUtility {
-  public static UserCustomUserDetails createTestUser() {
-    School school = School.builder()
-        .id(1L)
-        .name("가짜 학교")
-        .campus("가짜캠퍼스")
-        .build();
+  private final static School school = School.builder()
+      .id(1L)
+      .name("가짜 학교")
+      .campus("가짜캠퍼스")
+      .build();
+  private final static User user = User.builder()
+      .id(1L)
+      .email("test@test.com")
+      .password("password")
+      .school(school)
+      .build();
 
-    User user = User.builder()
-        .id(1L)
-        .email("test@test.com")
-        .password("password")
-        .school(school)
-        .build();
+  public static CustomUserDetails createTestUser() {
+    return new CustomUserDetails(user);
+  }
 
-    return new UserCustomUserDetails(user);
+  public static User getUser() {
+    return user;
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 로그인한 이용자의 비밀번호가 입력값과 일치하는지 확인하는 api가 필요했습니다.
- 로그인한 이용자의 비밀번호가 입력값과 일치하는지 확인하는 api의 테스트코드가 필요했습니다.

**TO-BE**
- 입력과 출력에 필요한 DTO를 생성했습니다.
  - 출력값으로 가져오기로 한 필드명 `isCorrected`의 경우 builder를 사용하여 직렬화할 시 `corrected`로 변환되는 문제가 있어 `@JsonProperty("isCorrected")`를 통해 값을 고정시켰습니다.
- 로그인한 이용자의 정보와 입력값을 함께 받아오는 컨트롤러를 생성하였습니다.
  - 일반 이용자, 사업자 등 권한과 관계없이 이용되는 api이기 때문에 UserDetails로 반환하게 하였습니다.
- 입력된 값을 암호화 시켰을 때 토큰에서 불러온 이용자의 비밀번호와 일치하는지 확인하는 서비스를 구현했습니다.
- api 컨트롤러, 서비스의 테스트코드를 작성하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 컨트롤러 테스트
    - 실제 서비스 호출 없이 테스트할 수 있도록 `SignServiceImpl`, `JwtValidationService`, `AuthApplication`에 대해 Mock설정.
    - `SecurityContextHolder`를 이용하여 테스트 유저 인증 정보를 세팅
    
      <details>
        <summary>passwordConfirm 과정</summary>

        - `VerifyPasswordRequest` 객체를 생성하여 비밀번호 확인 요청
        - `SignServiceImpl.passwordConfirm` 메서드를 Mocking하여 테스트 요청 시 예측 가능한 `VerifyPasswordResponse`를 반환하도록 설정
        - 테스트는 `/api/password-confirm` 엔드포인트에 POST 요청을 보내 반환된 응답의 HTTP 상태 코드와 JSON 응답 검증
      </details>
  - 서비스 테스트
    - 실제 암호화된 비밀번호를 검증하는 대신, 테스트에서 특정 결과를 반환하도록 `PasswordEncoder` 인터페이스를 Mocking
  
      <details>
        <summary>passwordConfirmSuccess: 일치하는 경우 테스트 과정</summary>

        - `rawPassword`와 `encodedPassword`가 일치할 때 `passwordConfirm` 메서드가 `true`를 반환하는지 확인
      </details>
      <details>
        <summary>passwordConfirmFailed: 불일치하는 경우 테스트 과정</summary>

        - `rawPassword`와 `encodedPassword`가 일치할 때 `passwordConfirm` 메서드가 `true`를 반환하는지 확인
      </details>
- [x] API 테스트 