### PR TITLE
feature: 사용자 정보 수정 기능 추가, refactor: User엔티티에 업데이트 함수 생성, test: 사용자 정보 수정 테스트

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/UserController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/UserController.java
@@ -1,0 +1,41 @@
+package com.zerobase.babdeusilbun.controller;
+
+import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
+
+import com.zerobase.babdeusilbun.dto.UserDto;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+  private final UserService userService;
+
+  /**
+   * 내 정보 수정
+   */
+  @PreAuthorize("hasRole('USER')")
+  @PatchMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<?> updateProfile(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @RequestPart(value = "file", required = false) MultipartFile image,
+      @RequestPart(value = "request") UserDto.UpdateRequest request) {
+    UserDto.UpdateRequest changeRequest = userService.updateProfile(user.getId(), image, request);
+
+    return (image != null && changeRequest.getImage() == null) ||
+        (request.getSchoolId() != null && changeRequest.getSchoolId() == null) ||
+        (request.getMajorId() != null && changeRequest.getMajorId() == null) ?
+        ResponseEntity.status(PARTIAL_CONTENT).build() : ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/domain/User.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/User.java
@@ -1,6 +1,7 @@
 package com.zerobase.babdeusilbun.domain;
 
 
+import com.zerobase.babdeusilbun.dto.UserDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -79,4 +80,18 @@ public class User extends BaseEntity{
     this.deletedAt = LocalDateTime.now();
   }
 
+  public void updateSchool(School school) {
+    this.school = school;
+  }
+
+  public void updateMajor(Major major) {
+    this.major = major;
+  }
+
+  public void update(UserDto.UpdateRequest request) {
+    if (request.getNickname() != null) this.nickname = request.getNickname();
+    if (request.getPassword() != null) this.password = request.getPassword();
+    if (request.getImage() != null) this.image = request.getImage();
+    if (request.getPhoneNumber() != null) this.phoneNumber = request.getPhoneNumber();
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/UserDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/UserDto.java
@@ -1,0 +1,19 @@
+package com.zerobase.babdeusilbun.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class UserDto {
+  @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class UpdateRequest {
+    private String nickname;
+    private String password;
+    private String image;
+    private String phoneNumber;
+    private Long schoolId;
+    private Long majorId;
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/UserService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/UserService.java
@@ -1,0 +1,8 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.dto.UserDto;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface UserService {
+  UserDto.UpdateRequest updateProfile(Long userId, MultipartFile image, UserDto.UpdateRequest request);
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
@@ -1,0 +1,92 @@
+package com.zerobase.babdeusilbun.service.impl;
+
+import static com.zerobase.babdeusilbun.exception.ErrorCode.USER_NOT_FOUND;
+import static com.zerobase.babdeusilbun.util.ImageUtility.USER_IMAGE_FOLDER;
+
+import com.zerobase.babdeusilbun.component.ImageComponent;
+import com.zerobase.babdeusilbun.domain.Major;
+import com.zerobase.babdeusilbun.domain.School;
+import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.UserDto.UpdateRequest;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.repository.MajorRepository;
+import com.zerobase.babdeusilbun.repository.SchoolRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.service.UserService;
+import io.micrometer.common.util.StringUtils;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@AllArgsConstructor
+public class UserServiceImpl implements UserService {
+  private final UserRepository userRepository;
+  private final SchoolRepository schoolRepository;
+  private final MajorRepository majorRepository;
+  private final ImageComponent imageComponent;
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  @Transactional
+  public UpdateRequest updateProfile(Long userId, MultipartFile image, UpdateRequest request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    updateSchool(user, request);
+    updateMajor(user, request);
+
+    if (image != null) {
+      updateImage(user, image, request);
+    } else if (request.getImage() != null && request.getImage().isEmpty() && StringUtils.isNotBlank(user.getImage())) {
+      imageComponent.deleteImageByUrl(user.getImage());
+    }
+
+    if (request.getPassword() != null) {
+      request.setPassword(passwordEncoder.encode(request.getPassword()));
+    }
+
+    user.update(request);
+    return request;
+  }
+
+  private void updateSchool(User user, UpdateRequest request) {
+    if (request.getSchoolId() == null) return;
+
+    School school = schoolRepository.findById(request.getSchoolId()).orElse(null);
+    if (school == null) {
+      request.setSchoolId(null);
+    }
+
+    user.updateSchool(school);
+  }
+
+  private void updateMajor(User user, UpdateRequest request) {
+    if (request.getMajorId() == null) return;
+
+    Major major = majorRepository.findById(request.getMajorId()).orElse(null);
+    if (major == null) {
+      request.setMajorId(null);
+      return;
+    }
+
+    user.updateMajor(major);
+  }
+
+  private void updateImage(User user, MultipartFile image, UpdateRequest request) {
+    List<String> uploadUrlList = imageComponent.uploadImageList(List.of(image), USER_IMAGE_FOLDER);
+    if (uploadUrlList.isEmpty()) {
+      request.setImage(null);
+      return;
+    }
+
+    if (StringUtils.isNotBlank(user.getImage())) {
+      imageComponent.deleteImageByUrl(user.getImage());
+    }
+
+    request.setImage(uploadUrlList.getFirst());
+  }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/controller/UserControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/UserControllerTest.java
@@ -1,0 +1,104 @@
+package com.zerobase.babdeusilbun.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.babdeusilbun.dto.UserDto.UpdateRequest;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.UserService;
+import com.zerobase.babdeusilbun.util.TestUserUtility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+public class UserControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private UserService userService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private CustomUserDetails testUser;
+
+  @BeforeEach
+  void setUp() {
+    //로그인 정보 세팅
+    testUser = TestUserUtility.createTestUser();
+
+    SecurityContextHolder.getContext().setAuthentication(
+        new UsernamePasswordAuthenticationToken(testUser, null, testUser.getAuthorities())
+    );
+  }
+
+  @DisplayName("내 정보 수정 컨트롤러 테스트(완전 성공)")
+  @Test
+  void updateProfileSuccess() throws Exception {
+    //given
+    UpdateRequest input = new UpdateRequest(
+        "nickname", "password", "url", "01012345678", 1L, 1L);
+    MockMultipartFile file = new MockMultipartFile(
+        "file", "image.png", "image/png", "image content".getBytes());
+    MockMultipartFile request = new MockMultipartFile(
+        "request", "request", "application/json",
+        objectMapper.writeValueAsString(input).getBytes());
+
+    //when
+    when(userService.updateProfile(eq(testUser.getId()), eq(file), eq(input))).thenReturn(input);
+
+    //then
+    mockMvc.perform(multipart("/api/users")
+            .file(file)
+            .file(request)
+            .with(csrf())
+            .with(httpRequest -> {
+              httpRequest.setMethod("PATCH");
+              return httpRequest;
+            }))
+        .andExpect(status().isOk());
+  }
+
+  @DisplayName("내 정보 수정 컨트롤러 테스트(부분 성공)")
+  @Test
+  void updateProfilePartialSuccess() throws Exception {
+    //given
+    UpdateRequest input = new UpdateRequest(
+        "nickname", "password", "url", "01012345678", 1L, 1L);
+    MockMultipartFile file = new MockMultipartFile(
+        "file", "image.png", "image/png", "image content".getBytes());
+    MockMultipartFile request = new MockMultipartFile(
+        "request", "request", "application/json",
+        objectMapper.writeValueAsString(input).getBytes());
+    UpdateRequest changeRequest = new UpdateRequest(
+        "nickname", "password", null, "01012345678", null, null);
+
+    //when
+    when(userService.updateProfile(eq(testUser.getId()), eq(file), eq(input))).thenReturn(input);
+
+    //then
+    mockMvc.perform(multipart("/api/users")
+            .file(file)
+            .file(request)
+            .with(csrf())
+            .with(httpRequest -> {
+              httpRequest.setMethod("PATCH");
+              return httpRequest;
+            }))
+        .andExpect(status().isPartialContent());
+  }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/UserServiceTest.java
@@ -1,0 +1,72 @@
+package com.zerobase.babdeusilbun.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.zerobase.babdeusilbun.component.ImageComponent;
+import com.zerobase.babdeusilbun.domain.Major;
+import com.zerobase.babdeusilbun.domain.School;
+import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.UserDto.UpdateRequest;
+import com.zerobase.babdeusilbun.repository.MajorRepository;
+import com.zerobase.babdeusilbun.repository.SchoolRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.service.impl.UserServiceImpl;
+import com.zerobase.babdeusilbun.util.TestUserUtility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private SchoolRepository schoolRepository;
+
+  @Mock
+  private MajorRepository majorRepository;
+
+  @Mock
+  private ImageComponent imageComponent;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @InjectMocks
+  private UserServiceImpl userService;
+
+  @DisplayName("내 정보 수정 테스트")
+  @Test
+  void updateProfile() {
+    // given
+    User user = TestUserUtility.getUser();
+    UpdateRequest request = new UpdateRequest(
+        "newNickname", "newPassword", null, null, 1L, 1L);
+    School school = new School();
+    Major major = new Major();
+    MultipartFile image = null;
+
+    String originImage = user.getImage();
+
+    when(userRepository.findById(eq(user.getId()))).thenReturn(java.util.Optional.of(user));
+    when(schoolRepository.findById(eq(request.getSchoolId()))).thenReturn(java.util.Optional.of(school));
+    when(majorRepository.findById(eq(request.getMajorId()))).thenReturn(java.util.Optional.of(major));
+    when(passwordEncoder.encode(eq(request.getPassword()))).thenReturn("encodedPassword");
+
+    // when
+    UpdateRequest updatedRequest = userService.updateProfile(1L, image, request);
+
+    // then
+    assertEquals("newNickname", user.getNickname());
+    assertEquals("encodedPassword", user.getPassword());
+    assertEquals(originImage, user.getImage());
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- `CustomUserDetails`에 ID, 이메일, 권한 정보가 저장되는 방식으로 구현되어 있습니다.
- 기존에 사용자의 정보를 수정하는 API가 없었고, 사용자 정보를 변경하는 기능이 미비했습니다.

**TO-BE**
- 새로운 사용자 정보 수정 API가 추가되었습니다. (`UserController.java`, `UserService.java`, `UserServiceImpl.java`)
  - 사용자는 닉네임, 비밀번호, 프로필 이미지, 전화번호, 학교, 전공 정보를 수정할 수 있습니다.
  - 이미지 업로드 및 삭제 기능이 추가되었습니다.
  - 비밀번호 암호화 처리 및 학교, 전공 정보의 유효성을 검증하도록 구현되었습니다.
- `UserDto.java`에 사용자 정보 수정 요청을 위한 `UpdateRequest` 클래스를 추가했습니다.
- `User` 엔티티에 학교 및 전공 정보를 업데이트하는 메서드가 추가되었습니다.
- 사용자가 자신의 정보를 수정할 때, 부분 성공(일부 필드만 수정된 경우)과 전체 성공을 나눠 응답하게 설정했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 컨트롤러 테스트
    - 실제 서비스 호출 없이 테스트할 수 있도록 `UserService`에 대해 Mock 설정.
    - `SecurityContextHolder`를 이용하여 테스트 유저 인증 정보를 세팅.
    
      <details>
        <summary>내 정보 수정 성공 테스트 과정</summary>

        - `UpdateRequest` 객체를 생성하여 정보 수정 요청.
        - `UserService.updateProfile` 메서드를 Mocking하여 테스트 요청 시 예측 가능한 `UpdateRequest`를 반환하도록 설정.
        - 테스트는 `/api/users` 엔드포인트에 PATCH 요청을 보내 반환된 응답의 HTTP 상태 코드와 JSON 응답 검증.
      </details>
      <details>
        <summary>내 정보 수정 부분 성공 테스트 과정</summary>

        - `UpdateRequest` 객체를 생성하여 정보 수정 요청.
        - 일부 필드 업데이트 실패를 시뮬레이션하여 부분 성공 상태 코드(PARTIAL_CONTENT) 반환을 검증.
      </details>
  - 서비스 테스트
    - 실제 DB와 연동하지 않고, 데이터 유효성을 검증하기 위해 `UserRepository`, `SchoolRepository`, `MajorRepository`, `ImageComponent`, `PasswordEncoder` 인터페이스를 Mocking.
  
      <details>
        <summary>내 정보 수정 서비스 테스트 과정</summary>

        - `User`, `School`, `Major` 객체를 Mock으로 설정하고, `UserService.updateProfile` 메서드 호출 시 기대하는 결과를 반환하도록 설정.
        - 요청된 닉네임, 비밀번호, 이미지, 전화번호 등의 값이 제대로 업데이트되었는지 검증.
      </details>
- [x] API 테스트