### PR TITLE
refactor: 로그인 로직 분리

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/security/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
 
     List<String> permitAllUrls = Arrays.asList(
         "/", "/api/users/sign**", "/api/businesses/sign**", "/h2-console/**",
-        "/swagger-ui/**", "/swagger-ui-custom.html", "/v3/api-docs/**"
+        "/swagger-ui/**", "/swagger-ui-custom.html", "/v3/api-docs/**", 
+        "/api/sign**"
     );
 
     http

--- a/src/main/java/com/zerobase/babdeusilbun/security/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/config/SecurityConfig.java
@@ -45,8 +45,7 @@ public class SecurityConfig {
 
     List<String> permitAllUrls = Arrays.asList(
         "/", "/api/users/sign**", "/api/businesses/sign**", "/h2-console/**",
-        "/swagger-ui/**", "/swagger-ui-custom.html", "/v3/api-docs/**",
-        "/api/sign**"
+        "/swagger-ui/**", "/swagger-ui-custom.html", "/v3/api-docs/**"
     );
 
     http

--- a/src/main/java/com/zerobase/babdeusilbun/security/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
     List<String> permitAllUrls = Arrays.asList(
-        "/", "/api/signin", "/api/users/sign**", "/api/businesses/sign**", "/h2-console/**",
+        "/", "/api/users/sign**", "/api/businesses/sign**", "/h2-console/**",
         "/swagger-ui/**", "/swagger-ui-custom.html", "/v3/api-docs/**",
         "/api/sign**"
     );

--- a/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
@@ -79,12 +79,23 @@ public class AuthController {
   }
 
   /**
-   * 로그인
+   * 사용자 로그인
    */
-  @PostMapping("/signin")
-  public ResponseEntity<?> signin(@Validated @RequestBody SignRequest.SignIn request) {
+  @PostMapping("/users/signin")
+  public ResponseEntity<?> userSignin(@Validated @RequestBody SignRequest.SignIn request) {
 
-    SignResponse response = authApplication.signin(request);
+    SignResponse response = authApplication.userSignin(request);
+
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 사업자 로그인
+   */
+  @PostMapping("/businesses/signin")
+  public ResponseEntity<?> businessSignin(@Validated @RequestBody SignRequest.SignIn request) {
+
+    SignResponse response = authApplication.businessSignin(request);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
@@ -15,6 +15,7 @@ import com.zerobase.babdeusilbun.security.service.JwtValidationService;
 import com.zerobase.babdeusilbun.security.service.SignService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -103,6 +104,7 @@ public class AuthController {
   /**
    * 로그아웃
    */
+  @PreAuthorize("hasAnyRole('USER', 'ENTREPRENEUR')")
   @PostMapping("/logout")
   public ResponseEntity<?> logout(
       @RequestHeader("Authorization") String authorizationHeader
@@ -114,6 +116,10 @@ public class AuthController {
     return ResponseEntity.status(OK).build();
   }
 
+  /**
+   * 사용자 회원탈퇴
+   */
+  @PreAuthorize("hasAnyRole('USER')")
   @PostMapping("/users/withdrawal")
   public ResponseEntity<?> userWithdrawal(
       @RequestHeader("Authorization") String authorizationHeader,
@@ -127,6 +133,10 @@ public class AuthController {
     return ResponseEntity.status(OK).build();
   }
 
+  /**
+   * 사업자 회원탈퇴
+   */
+  @PreAuthorize("hasAnyRole('ENTREPRENEUR')")
   @PostMapping("/businesses/withdrawal")
   public ResponseEntity<?> entrepreneurWithdrawal(
       @RequestHeader("Authorization") String authorizationHeader,


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
기존 로직에서 사용자와 사업가의 로그인 로직이 합쳐져 있어 회원가입 시 동시에 여러명이 동일한 이메일로 가입을 시도해 중복 이메일이 발생했을 경우 문제가 발생할 수 있었습니다

**TO-BE**
사용자와 사업가의 로그인 엔트포인트를 분리해 동시성 문제를 해결하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 