### PR TITLE
feat : 닉네임 무작위 생성 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
@@ -16,7 +16,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
   @Query("select m from meeting m "
       + "join purchase p on p.meeting = m "
-      + "where p.user = :user "
+      + "where p.user = :participant "
       + "and m.status != 'MEETING_CANCELLED' and m.status != 'MEETING_COMPLETED' ")
   List<Meeting> findProceedingByParticipant(User participant);
 

--- a/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
@@ -217,9 +217,7 @@ public class SignServiceImpl implements SignService {
         .email(request.getEmail())
         .password(passwordEncoder.encode(request.getPassword()))
         .isBanned(false)
-        //TODO
-        // 닉네임 생성 유틸 필요
-        .nickname("testnickname")
+        .nickname(createNickname())
         .name(request.getName())
         .phoneNumber(request.getPhoneNumber())
         .point(0L)
@@ -271,5 +269,26 @@ public class SignServiceImpl implements SignService {
     if (!proceedingPurchase.isEmpty()) {
       throw new CustomException(ENTREPRENEUR_ORDER_PROCEEDING);
     }
+  }
+
+  private String createNickname() {
+    String[] modifiers = {
+            "배고픈", "굶주린", "예민한", "소심한", "대담한", "인기많은", "섬세한"
+    };
+    String[] nouns = {
+            "돼지", "병아리", "고양이", "강아지", "플라톤",
+            "아리스토텔레스", "소크라테스", "학생", "대학원생",
+            "예비대학원생", "탈출자", "기숙사생", "망령"
+    };
+
+    StringBuilder nickname = new StringBuilder("");
+
+    nickname.append(modifiers[(int) (Math.random() * modifiers.length)]);
+    nickname.append(nouns[(int) (Math.random() * nouns.length)]);
+    for(int i = 0; i < 3; i++) {
+      nickname.append((int) (Math.random() * 10));
+    }
+
+    return nickname.toString();
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 회원가입 시 사용자의 닉네임이 무작위로 생성되는 기능이 미구현 상태였습니다.

**TO-BE**
- `SignServiceImpl.java`에서 사용자 닉네임 무작위 생성 메서드(`createNickname()`)를 구현하였습니다.
  - 수식어, 명사, 3자리의 숫자 조합으로 닉네임을 생성해서 중복을 최소화 하였습니다.
  - 수식어, 명사는 등록되어 있는 내용들 중에서 랜덤으로 1개씩 선택이 되도록 구현하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
