### PR TITLE
feature: 문의 게시글 작성, 이미지 등록,수정, 문의 삭제 기능

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/domain/InquiryImage.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/InquiryImage.java
@@ -38,4 +38,8 @@ public class InquiryImage extends BaseEntity{
   @Column(nullable = false)
   private Integer sequence;
 
+  public void changeSequence(int sequence) {
+    this.sequence = sequence;
+  }
+
 }

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -67,7 +67,10 @@ public enum ErrorCode {
   FAILED_SEND_MAIL(CONFLICT, "failed to send mail."),
 
   // 문의 관련
-  INQUIRY_NOT_FOUND(BAD_REQUEST, "couldn't find inquiry")
+  INQUIRY_NOT_FOUND(BAD_REQUEST, "couldn't find inquiry"),
+  INQUIRY_WRITER_NOT_MATCH(BAD_REQUEST, "this user is not writer of that inquiry"),
+  INQUIRY_IMAGE_NOT_FOUND(BAD_REQUEST, "couldn't find inquiry image"),
+  INQUIRY_IMAGE_SEQUENCE_INVALID(BAD_REQUEST, "inquiry image sequence is invalid")
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -64,7 +64,10 @@ public enum ErrorCode {
   //이메일 인증 관련
   CANNOT_SEND_MAIL_EXCEEDS_MAX_COUNT(BAD_REQUEST,
       "the number of attempts requested to send mail exceeds the maximum allowed count."),
-  FAILED_SEND_MAIL(CONFLICT, "failed to send mail.")
+  FAILED_SEND_MAIL(CONFLICT, "failed to send mail."),
+
+  // 문의 관련
+  INQUIRY_NOT_FOUND(BAD_REQUEST, "couldn't find inquiry")
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -70,7 +70,8 @@ public enum ErrorCode {
   INQUIRY_NOT_FOUND(BAD_REQUEST, "couldn't find inquiry"),
   INQUIRY_WRITER_NOT_MATCH(BAD_REQUEST, "this user is not writer of that inquiry"),
   INQUIRY_IMAGE_NOT_FOUND(BAD_REQUEST, "couldn't find inquiry image"),
-  INQUIRY_IMAGE_SEQUENCE_INVALID(BAD_REQUEST, "inquiry image sequence is invalid")
+  INQUIRY_IMAGE_SEQUENCE_INVALID(BAD_REQUEST, "inquiry image sequence is invalid"),
+  INQUIRY_IMAGE_AND_INQUIRY_NOT_MATCH(BAD_REQUEST, "image and inquiry is not match")
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -67,9 +67,10 @@ public enum ErrorCode {
   FAILED_SEND_MAIL(CONFLICT, "failed to send mail."),
 
   // 문의 관련
-  INQUIRY_NOT_FOUND(BAD_REQUEST, "couldn't find inquiry"),
+  INQUIRY_NOT_FOUND(NOT_FOUND, "couldn't find inquiry"),
   INQUIRY_WRITER_NOT_MATCH(BAD_REQUEST, "this user is not writer of that inquiry"),
-  INQUIRY_IMAGE_NOT_FOUND(BAD_REQUEST, "couldn't find inquiry image"),
+
+  INQUIRY_IMAGE_NOT_FOUND(NOT_FOUND, "couldn't find inquiry image"),
   INQUIRY_IMAGE_SEQUENCE_INVALID(BAD_REQUEST, "inquiry image sequence is invalid"),
   INQUIRY_IMAGE_AND_INQUIRY_NOT_MATCH(BAD_REQUEST, "image and inquiry is not match")
   ;

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -1,10 +1,16 @@
 package com.zerobase.babdeusilbun.inquiry.controller;
 
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,8 +23,11 @@ public class InquiryController {
 
   // 문의 게시물 목록 조회
   @GetMapping
-  public ResponseEntity<?> getInquiryList() {
+  public ResponseEntity<?> getInquiryList(
+      @RequestParam String statusFilter, Pageable pageable
+  ) {
 
+    return ResponseEntity.ok(inquiryService.getInquiryList(statusFilter, pageable));
   }
 
   // 문의 게시물 상세 조회 /{inquiryId}

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -84,6 +85,16 @@ public class InquiryController {
   }
 
 
-  // 문의 이미지 삭제  /images/{imageId}
+  // 문의 이미지 삭제
+  @DeleteMapping("/{inquiryId}/images/{imageId}")
+  public ResponseEntity<?> deleteInquiryImage(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long inquiryId, @PathVariable Long imageId
+  ) {
+
+    inquiryService.deleteImage(userDetails, inquiryId, imageId);
+
+    return ResponseEntity.status(OK).build();
+  }
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.*;
 
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryImageDto;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import java.util.List;
@@ -62,6 +63,13 @@ public class InquiryController {
   }
 
   // 문의 이미지 전체 조회 /images
+  @GetMapping("/{inquiryId}/images")
+  public ResponseEntity<?> getInquiryImages(@PathVariable Long inquiryId, Pageable pageable) {
+
+    Page<InquiryImageDto> imageDtos = inquiryService.getInquiryImageList(inquiryId, pageable);
+
+    return ResponseEntity.ok(null);
+  }
 
   // 문의 이미지 순서 변경  /images/{imageId}
 

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,6 +32,12 @@ public class InquiryController {
   }
 
   // 문의 게시물 상세 조회 /{inquiryId}
+  @GetMapping("/{inquiryId}")
+  public ResponseEntity<?> getInquiryInfo(@PathVariable Long inquiryId) {
+
+    return ResponseEntity.ok(inquiryService.getInquiryInfo(inquiryId));
+  }
+
 
   // 문의 게시글 작성
 

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -1,0 +1,14 @@
+package com.zerobase.babdeusilbun.inquiry.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+
+
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,7 +43,7 @@ public class InquiryController {
     return ResponseEntity.ok(inquiryService.getInquiryList(statusFilter, pageable));
   }
 
-  // 문의 게시물 상세 조회 /{inquiryId}
+  // 문의 게시물 상세 조회
   @GetMapping("/{inquiryId}")
   public ResponseEntity<?> getInquiryInfo(@PathVariable Long inquiryId) {
 
@@ -62,16 +63,26 @@ public class InquiryController {
     return ResponseEntity.status(CREATED).build();
   }
 
-  // 문의 이미지 전체 조회 /images
+  // 문의 이미지 전체 조회
   @GetMapping("/{inquiryId}/images")
   public ResponseEntity<?> getInquiryImages(@PathVariable Long inquiryId, Pageable pageable) {
 
-    Page<InquiryImageDto> imageDtos = inquiryService.getInquiryImageList(inquiryId, pageable);
-
-    return ResponseEntity.ok(null);
+    return ResponseEntity.ok(inquiryService.getInquiryImageList(inquiryId, pageable));
   }
 
-  // 문의 이미지 순서 변경  /images/{imageId}
+  // 문의 이미지 순서 변경
+  @PatchMapping("/{inquiryId}/images/{imageId}")
+  public ResponseEntity<?> updateInquiryImageSequence(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long inquiryId, @PathVariable Long imageId,
+      @RequestParam Integer sequence
+  ) {
+
+    inquiryService.updateImageSequence(userDetails, inquiryId, imageId, sequence);
+
+    return ResponseEntity.status(OK).build();
+  }
+
 
   // 문의 이미지 삭제  /images/{imageId}
 

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -1,6 +1,9 @@
 package com.zerobase.babdeusilbun.inquiry.controller;
 
+import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,5 +13,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class InquiryController {
 
 
+  private final InquiryService inquiryService;
+
+  // 문의 게시물 목록 조회
+  @GetMapping
+  public ResponseEntity<?> getInquiryList() {
+
+  }
+
+  // 문의 게시물 상세 조회 /{inquiryId}
+
+  // 문의 게시글 작성
+
+  // 문의 이미지 전체 조회 /images
+
+  // 문의 이미지 순서 변경  /images/{imageId}
+
+  // 문의 이미지 삭제  /images/{imageId}
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -1,18 +1,28 @@
 package com.zerobase.babdeusilbun.inquiry.controller;
 
+import static org.springframework.http.HttpStatus.*;
+
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/users/inquiries")
@@ -38,8 +48,18 @@ public class InquiryController {
     return ResponseEntity.ok(inquiryService.getInquiryInfo(inquiryId));
   }
 
-
   // 문의 게시글 작성
+  @PostMapping
+  public ResponseEntity<?> createInquiry(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Validated @RequestPart("request") InquiryDto.Request request,
+      @RequestPart(value = "files", required = false) List<MultipartFile> images
+  ) {
+
+    inquiryService.createInquiry(userDetails, request, images);
+
+    return ResponseEntity.status(CREATED).build();
+  }
 
   // 문의 이미지 전체 조회 /images
 

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/dto/InquiryDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/dto/InquiryDto.java
@@ -1,0 +1,82 @@
+package com.zerobase.babdeusilbun.inquiry.dto;
+
+import com.zerobase.babdeusilbun.domain.Inquiry;
+import com.zerobase.babdeusilbun.enums.InquiryStatus;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class InquiryDto {
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @Builder
+  public static class Request {
+
+    private String title;
+    private String content;
+
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @Builder
+  public static class ListResponse {
+
+    private Long inquiryId;
+
+    private String title;
+
+    private InquiryStatus status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private static InquiryDto.ListResponse fromEntity(Inquiry inquiry) {
+      return ListResponse.builder()
+          .inquiryId(inquiry.getId())
+          .title(inquiry.getTitle())
+          .status(inquiry.getStatus())
+          .createdAt(inquiry.getCreatedAt())
+          .updatedAt(inquiry.getUpdatedAt())
+          .build();
+    }
+
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @Builder
+  public static class DetailResponse {
+
+    private Long inquiryId;
+
+    private String title;
+    private String content;
+    private String answer;
+
+    private InquiryStatus status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static InquiryDto.DetailResponse fromEntity(Inquiry inquiry) {
+      return DetailResponse.builder()
+          .inquiryId(inquiry.getId())
+          .title(inquiry.getTitle())
+          .content(inquiry.getContent())
+          .status(inquiry.getStatus())
+          .createdAt(inquiry.getCreatedAt())
+          .updatedAt(inquiry.getUpdatedAt())
+          .build();
+    }
+
+  }
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/dto/InquiryDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/dto/InquiryDto.java
@@ -2,6 +2,7 @@ package com.zerobase.babdeusilbun.inquiry.dto;
 
 import com.zerobase.babdeusilbun.domain.Inquiry;
 import com.zerobase.babdeusilbun.enums.InquiryStatus;
+import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,7 +18,9 @@ public class InquiryDto {
   @Builder
   public static class Request {
 
+    @NotBlank(message = "title에는 빈 값이 올 수 없습니다.")
     private String title;
+    @NotBlank(message = "content에는 빈 값이 올 수 없습니다.")
     private String content;
 
   }
@@ -37,7 +40,7 @@ public class InquiryDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    private static InquiryDto.ListResponse fromEntity(Inquiry inquiry) {
+    public static InquiryDto.ListResponse fromEntity(Inquiry inquiry) {
       return ListResponse.builder()
           .inquiryId(inquiry.getId())
           .title(inquiry.getTitle())

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/dto/InquiryImageDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/dto/InquiryImageDto.java
@@ -1,0 +1,26 @@
+package com.zerobase.babdeusilbun.inquiry.dto;
+
+import com.zerobase.babdeusilbun.domain.InquiryImage;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class InquiryImageDto {
+
+  private Long imageId;
+  private String url;
+  private Integer sequence;
+
+  public static InquiryImageDto fromEntity(InquiryImage image) {
+    return InquiryImageDto.builder()
+        .imageId(image.getId()).url(image.getUrl()).sequence(image.getSequence())
+        .build();
+  }
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
@@ -3,6 +3,7 @@ package com.zerobase.babdeusilbun.inquiry.service;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.Request;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryImageDto;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -16,4 +17,6 @@ public interface InquiryService {
   InquiryDto.DetailResponse getInquiryInfo(Long inquiryId);
 
   void createInquiry(CustomUserDetails userDetails, Request request, List<MultipartFile> images);
+
+  Page<InquiryImageDto> getInquiryImageList(Long inquiryId, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
@@ -19,4 +19,6 @@ public interface InquiryService {
   void createInquiry(CustomUserDetails userDetails, Request request, List<MultipartFile> images);
 
   Page<InquiryImageDto> getInquiryImageList(Long inquiryId, Pageable pageable);
+
+  void updateImageSequence(CustomUserDetails userDetails, Long inquiryId, Long imageId, Integer updatedSequence);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
@@ -21,4 +21,6 @@ public interface InquiryService {
   Page<InquiryImageDto> getInquiryImageList(Long inquiryId, Pageable pageable);
 
   void updateImageSequence(CustomUserDetails userDetails, Long inquiryId, Long imageId, Integer updatedSequence);
+
+  void deleteImage(CustomUserDetails userDetails, Long inquiryId, Long imageId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
@@ -1,5 +1,11 @@
 package com.zerobase.babdeusilbun.inquiry.service;
 
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface InquiryService {
 
+  Page<ListResponse> getInquiryList(String statusFilter, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
@@ -1,5 +1,6 @@
 package com.zerobase.babdeusilbun.inquiry.service;
 
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -8,4 +9,7 @@ import org.springframework.data.domain.Pageable;
 public interface InquiryService {
 
   Page<ListResponse> getInquiryList(String statusFilter, Pageable pageable);
+
+  InquiryDto.DetailResponse getInquiryInfo(Long inquiryId);
+
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
@@ -2,9 +2,12 @@ package com.zerobase.babdeusilbun.inquiry.service;
 
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.Request;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface InquiryService {
 
@@ -12,4 +15,5 @@ public interface InquiryService {
 
   InquiryDto.DetailResponse getInquiryInfo(Long inquiryId);
 
+  void createInquiry(CustomUserDetails userDetails, Request request, List<MultipartFile> images);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
@@ -1,0 +1,5 @@
+package com.zerobase.babdeusilbun.inquiry.service;
+
+public interface InquiryService {
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -18,6 +18,7 @@ import com.zerobase.babdeusilbun.repository.InquiryImageRepository;
 import com.zerobase.babdeusilbun.repository.InquiryRepository;
 import com.zerobase.babdeusilbun.repository.UserRepository;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -98,14 +99,14 @@ public class InquiryServiceImpl implements InquiryService {
     verifyImageSequenceRequest(inquiryImageList, updatedSequence);
 
     // sequence 재배치
-    InquiryImage targetInquiryImage = inquiryImageList.remove(originalSequence);
-    inquiryImageList.add(updatedSequence, targetInquiryImage);
+    InquiryImage targetInquiryImage = inquiryImageList.remove(originalSequence - 1);
+    inquiryImageList.add(updatedSequence - 1, targetInquiryImage);
 
     allocateSequence(inquiryImageList);
   }
 
   private void verifyImageSequenceRequest(List<InquiryImage> inquiryImageList, Integer updatedSequence) {
-    if (updatedSequence >= 1 && updatedSequence <= inquiryImageList.size() + 1) {
+    if (updatedSequence < 1 || updatedSequence > inquiryImageList.size() + 1) {
       throw new CustomException(INQUIRY_IMAGE_SEQUENCE_INVALID);
     }
   }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -2,25 +2,22 @@ package com.zerobase.babdeusilbun.inquiry.service.impl;
 
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
-import com.zerobase.babdeusilbun.repository.InquiryQueryRepository;
-import java.util.List;
+import com.zerobase.babdeusilbun.repository.custom.impl.CustomInquiryRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.GetMapping;
 
 @Service
 @RequiredArgsConstructor
 public class InquiryServiceImpl implements InquiryService {
 
-  private final InquiryQueryRepository inquiryQueryRepository;
+  private final CustomInquiryRepositoryImpl customInquiryRepositoryImpl;
 
 
   @Override
   public Page<ListResponse> getInquiryList(String statusFilter, Pageable pageable) {
-    return inquiryQueryRepository
+    return customInquiryRepositoryImpl
         .findInquiryList(statusFilter, pageable).map(ListResponse::fromEntity);
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -2,7 +2,7 @@ package com.zerobase.babdeusilbun.inquiry.service.impl;
 
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
-import com.zerobase.babdeusilbun.repository.custom.impl.CustomInquiryRepositoryImpl;
+import com.zerobase.babdeusilbun.repository.InquiryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,12 +12,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class InquiryServiceImpl implements InquiryService {
 
-  private final CustomInquiryRepositoryImpl customInquiryRepositoryImpl;
+  private final InquiryRepository inquiryRepository;
 
 
   @Override
   public Page<ListResponse> getInquiryList(String statusFilter, Pageable pageable) {
-    return customInquiryRepositoryImpl
+    return inquiryRepository
         .findInquiryList(statusFilter, pageable).map(ListResponse::fromEntity);
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -1,24 +1,39 @@
 package com.zerobase.babdeusilbun.inquiry.service.impl;
 
+import static com.zerobase.babdeusilbun.enums.InquiryStatus.*;
 import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
 
+import com.zerobase.babdeusilbun.component.ImageComponent;
 import com.zerobase.babdeusilbun.domain.Inquiry;
+import com.zerobase.babdeusilbun.domain.InquiryImage;
+import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.exception.CustomException;
-import com.zerobase.babdeusilbun.exception.ErrorCode;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.DetailResponse;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.Request;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
+import com.zerobase.babdeusilbun.repository.InquiryImageRepository;
 import com.zerobase.babdeusilbun.repository.InquiryRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.util.ImageUtility;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class InquiryServiceImpl implements InquiryService {
 
   private final InquiryRepository inquiryRepository;
+  private final InquiryImageRepository inquiryImageRepository;
+  private final UserRepository userRepository;
+
+  private final ImageComponent imageComponent;
 
 
   @Override
@@ -30,6 +45,53 @@ public class InquiryServiceImpl implements InquiryService {
   @Override
   public DetailResponse getInquiryInfo(Long inquiryId) {
     return DetailResponse.fromEntity(findInquiryById(inquiryId));
+  }
+
+  @Override
+  public void createInquiry
+      (CustomUserDetails userDetails, Request request, List<MultipartFile> images) {
+
+    User findUser = findUserByUserDetails(userDetails);
+
+    // 새로운 Inquiry 생성
+    Inquiry createdInquiry = createNewInquiry(findUser, request);
+    Inquiry savedInquiry = inquiryRepository.save(createdInquiry);
+
+    // Inquiry image 저장
+    List<String> uploadedImageUrlList =
+        imageComponent.uploadImageList(images, ImageUtility.INQUIRY_IMAGE_FOLDER);
+
+    List<InquiryImage> inquiryImageList = mapToInquiryImageEntity(savedInquiry, uploadedImageUrlList);
+    inquiryImageRepository.saveAll(inquiryImageList);
+
+  }
+
+  private List<InquiryImage> mapToInquiryImageEntity(Inquiry inquiry, List<String> uploadedImageList) {
+    return fromUrlToImageEntity(inquiry, uploadedImageList);
+  }
+
+  private List<InquiryImage> fromUrlToImageEntity(Inquiry inquiry, List<String> uploadedImageList) {
+    AtomicInteger sequence = new AtomicInteger(1);
+
+    return uploadedImageList.stream().map(url -> InquiryImage.builder()
+        .inquiry(inquiry)
+        .url(url)
+        .sequence(sequence.getAndIncrement())
+        .build()).toList();
+  }
+
+  private Inquiry createNewInquiry(User user, Request request) {
+    return Inquiry.builder()
+        .user(user)
+        .title(request.getTitle())
+        .content(request.getContent())
+        .status(PENDING)
+        .build();
+  }
+
+  private User findUserByUserDetails(CustomUserDetails userDetails) {
+    return userRepository.findById(userDetails.getId())
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
   }
 
   private Inquiry findInquiryById(Long inquiryId) {

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -2,10 +2,13 @@ package com.zerobase.babdeusilbun.inquiry.service.impl;
 
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Service
 @RequiredArgsConstructor
 public class InquiryServiceImpl implements InquiryService {
+
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -1,0 +1,11 @@
+package com.zerobase.babdeusilbun.inquiry.service.impl;
+
+import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryServiceImpl implements InquiryService {
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -1,5 +1,11 @@
 package com.zerobase.babdeusilbun.inquiry.service.impl;
 
+import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
+
+import com.zerobase.babdeusilbun.domain.Inquiry;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.exception.ErrorCode;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.DetailResponse;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
 import com.zerobase.babdeusilbun.repository.InquiryRepository;
@@ -19,5 +25,15 @@ public class InquiryServiceImpl implements InquiryService {
   public Page<ListResponse> getInquiryList(String statusFilter, Pageable pageable) {
     return inquiryRepository
         .findInquiryList(statusFilter, pageable).map(ListResponse::fromEntity);
+  }
+
+  @Override
+  public DetailResponse getInquiryInfo(Long inquiryId) {
+    return DetailResponse.fromEntity(findInquiryById(inquiryId));
+  }
+
+  private Inquiry findInquiryById(Long inquiryId) {
+    return inquiryRepository.findById(inquiryId)
+        .orElseThrow(() -> new CustomException(INQUIRY_NOT_FOUND));
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -12,12 +12,12 @@ import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.DetailResponse;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.Request;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryImageDto;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
 import com.zerobase.babdeusilbun.repository.InquiryImageRepository;
 import com.zerobase.babdeusilbun.repository.InquiryRepository;
 import com.zerobase.babdeusilbun.repository.UserRepository;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
-import com.zerobase.babdeusilbun.util.ImageUtility;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
@@ -65,6 +65,13 @@ public class InquiryServiceImpl implements InquiryService {
     List<InquiryImage> inquiryImageList = mapToInquiryImageEntity(savedInquiry, uploadedImageUrlList);
     inquiryImageRepository.saveAll(inquiryImageList);
 
+  }
+
+  @Override
+  public Page<InquiryImageDto> getInquiryImageList(Long inquiryId, Pageable pageable) {
+
+    return inquiryImageRepository.findAllByInquiryOrderBySequence(findInquiryById(inquiryId), pageable)
+        .map(InquiryImageDto::fromEntity);
   }
 
   private List<InquiryImage> mapToInquiryImageEntity(Inquiry inquiry, List<String> uploadedImageList) {

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -1,7 +1,12 @@
 package com.zerobase.babdeusilbun.inquiry.service.impl;
 
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
+import com.zerobase.babdeusilbun.repository.InquiryQueryRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,5 +15,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 @RequiredArgsConstructor
 public class InquiryServiceImpl implements InquiryService {
 
+  private final InquiryQueryRepository inquiryQueryRepository;
 
+
+  @Override
+  public Page<ListResponse> getInquiryList(String statusFilter, Pageable pageable) {
+    return inquiryQueryRepository
+        .findInquiryList(statusFilter, pageable).map(ListResponse::fromEntity);
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -2,6 +2,7 @@ package com.zerobase.babdeusilbun.inquiry.service.impl;
 
 import static com.zerobase.babdeusilbun.enums.InquiryStatus.*;
 import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
+import static com.zerobase.babdeusilbun.util.ImageUtility.*;
 
 import com.zerobase.babdeusilbun.component.ImageComponent;
 import com.zerobase.babdeusilbun.domain.Inquiry;
@@ -59,7 +60,7 @@ public class InquiryServiceImpl implements InquiryService {
 
     // Inquiry image 저장
     List<String> uploadedImageUrlList =
-        imageComponent.uploadImageList(images, ImageUtility.INQUIRY_IMAGE_FOLDER);
+        imageComponent.uploadImageList(images, INQUIRY_IMAGE_FOLDER);
 
     List<InquiryImage> inquiryImageList = mapToInquiryImageEntity(savedInquiry, uploadedImageUrlList);
     inquiryImageRepository.saveAll(inquiryImageList);

--- a/src/main/java/com/zerobase/babdeusilbun/repository/InquiryImageRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/InquiryImageRepository.java
@@ -1,7 +1,12 @@
 package com.zerobase.babdeusilbun.repository;
 
+import com.zerobase.babdeusilbun.domain.Inquiry;
 import com.zerobase.babdeusilbun.domain.InquiryImage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InquiryImageRepository extends JpaRepository<InquiryImage, Long> {
+
+  Page<InquiryImage> findAllByInquiryOrderBySequence(Inquiry inquiry, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/InquiryImageRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/InquiryImageRepository.java
@@ -2,11 +2,23 @@ package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Inquiry;
 import com.zerobase.babdeusilbun.domain.InquiryImage;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface InquiryImageRepository extends JpaRepository<InquiryImage, Long> {
 
   Page<InquiryImage> findAllByInquiryOrderBySequence(Inquiry inquiry, Pageable pageable);
+
+  List<InquiryImage> findAllByInquiryOrderBySequence(Inquiry inquiry);
+
+  @Query("select ii from inquiry_image ii "
+        + "where ii.inquiry = :inquiry "
+        + "and ii != :image "
+        + "order by ii.sequence asc")
+  List<InquiryImage> findAllExceptUpdatedImage(Inquiry inquiry, InquiryImage image);
+
+  List<InquiryImage> findAllByInquiry(Inquiry inquiry);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/InquiryQueryRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/InquiryQueryRepository.java
@@ -1,0 +1,55 @@
+package com.zerobase.babdeusilbun.repository;
+
+import static com.zerobase.babdeusilbun.domain.QInquiry.*;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.babdeusilbun.domain.Inquiry;
+import com.zerobase.babdeusilbun.enums.InquiryStatus;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class InquiryQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  public Page<Inquiry> findInquiryList(String statusFilter, Pageable pageable) {
+
+    List<Inquiry> inquiryList = queryFactory.selectFrom(inquiry)
+        .where(where(statusFilter))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    Long count = queryFactory.select(inquiry.id.count())
+        .where(where(statusFilter))
+        .fetchOne();
+
+    return new PageImpl<>(inquiryList, pageable, count);
+  }
+
+  private BooleanExpression[] where(String statusFilter) {
+    List<BooleanExpression> list = new ArrayList<>();
+
+    if (!StringUtils.hasText(statusFilter)) {
+      return list.toArray(new BooleanExpression[0]);
+    }
+
+    list.add(whereStatusFilter(statusFilter));
+
+    return list.toArray(new BooleanExpression[0]);
+  }
+
+  private BooleanExpression whereStatusFilter(String statusFilter) {
+    return inquiry.status.eq(InquiryStatus.valueOf(statusFilter));
+  }
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/repository/InquiryRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/InquiryRepository.java
@@ -1,7 +1,8 @@
 package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Inquiry;
+import com.zerobase.babdeusilbun.repository.custom.CustomInquiryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+public interface InquiryRepository extends JpaRepository<Inquiry, Long>, CustomInquiryRepository {
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomInquiryRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomInquiryRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.babdeusilbun.repository.custom;
+
+import com.zerobase.babdeusilbun.domain.Inquiry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomInquiryRepository {
+
+  Page<Inquiry> findInquiryList(String statusFilter, Pageable pageable);
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomInquiryRepositoryImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomInquiryRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.zerobase.babdeusilbun.repository;
+package com.zerobase.babdeusilbun.repository.custom.impl;
 
 import static com.zerobase.babdeusilbun.domain.QInquiry.*;
 
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zerobase.babdeusilbun.domain.Inquiry;
 import com.zerobase.babdeusilbun.enums.InquiryStatus;
+import com.zerobase.babdeusilbun.repository.custom.CustomInquiryRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +18,11 @@ import org.springframework.util.StringUtils;
 
 @Repository
 @RequiredArgsConstructor
-public class InquiryQueryRepository {
+public class CustomInquiryRepositoryImpl implements CustomInquiryRepository {
 
   private final JPAQueryFactory queryFactory;
 
+  @Override
   public Page<Inquiry> findInquiryList(String statusFilter, Pageable pageable) {
 
     List<Inquiry> inquiryList = queryFactory.selectFrom(inquiry)

--- a/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
@@ -207,7 +207,47 @@ class InquiryServiceTest {
     assertThat(image3.getSequence()).isEqualTo(2);
     assertThat(image4.getSequence()).isEqualTo(3);
     assertThat(image5.getSequence()).isEqualTo(5);
+  }
 
+  @Test
+  @DisplayName("문의 이미지 삭제")
+  void deleteImageSequence() throws Exception {
+    // given
+    User user = User.builder().id(1L).email("test").build();
+    CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+    Inquiry inquiry = Inquiry.builder().id(1L).user(user).build();
+
+    InquiryImage image1 = InquiryImage.builder().id(1L).inquiry(inquiry).url("1").sequence(1).build();
+    InquiryImage image2 = InquiryImage.builder().id(2L).inquiry(inquiry).url("2").sequence(2).build();
+    InquiryImage image3 = InquiryImage.builder().id(3L).inquiry(inquiry).url("3").sequence(3).build();
+    InquiryImage image4 = InquiryImage.builder().id(4L).inquiry(inquiry).url("4").sequence(4).build();
+    InquiryImage image5 = InquiryImage.builder().id(5L).inquiry(inquiry).url("5").sequence(5).build();
+    List<InquiryImage> imageList = new ArrayList<>();
+    imageList.add(image1);
+    imageList.add(image2);
+    imageList.add(image3);
+    imageList.add(image4);
+    imageList.add(image5);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(inquiryRepository.findById(1L)).thenReturn(Optional.of(inquiry));
+//    when(inquiryImageRepository.findById(1L)).thenReturn(Optional.of(image1));
+    when(inquiryImageRepository.findById(2L)).thenReturn(Optional.of(image2));
+//    when(inquiryImageRepository.findById(3L)).thenReturn(Optional.of(image3));
+//    when(inquiryImageRepository.findById(4L)).thenReturn(Optional.of(image4));
+//    when(inquiryImageRepository.findById(5L)).thenReturn(Optional.of(image5));
+    when(inquiryImageRepository.findAllByInquiry(any())).thenReturn(imageList);
+
+    // when
+    inquiryService.deleteImage(customUserDetails, 1L, 2L);
+
+    // then
+    verify(inquiryImageRepository, times(1)).delete(any());
+    assertThat(image1.getSequence()).isEqualTo(1);
+    assertThat(image3.getSequence()).isEqualTo(2);
+    assertThat(image4.getSequence()).isEqualTo(3);
+    assertThat(image5.getSequence()).isEqualTo(4);
   }
 
 }

--- a/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
@@ -1,0 +1,94 @@
+package com.zerobase.babdeusilbun.inquiry.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.zerobase.babdeusilbun.domain.Inquiry;
+import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.enums.InquiryStatus;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.DetailResponse;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
+import com.zerobase.babdeusilbun.inquiry.service.impl.InquiryServiceImpl;
+import com.zerobase.babdeusilbun.repository.InquiryRepository;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class InquiryServiceTest {
+
+  @InjectMocks
+  private InquiryServiceImpl inquiryService;
+  @Mock
+  private InquiryRepository inquiryRepository;
+
+  @Test
+  @DisplayName("문의 목록 조회")
+  void InquiryList() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Inquiry pending = Inquiry.builder()
+        .user(user).title("title1").content("content1")
+        .status(InquiryStatus.PENDING).build();
+    Inquiry complete = Inquiry.builder()
+        .user(user).title("title1").content("content1")
+        .status(InquiryStatus.COMPLETED).build();
+
+    Pageable pageable = PageRequest.of(0, 2);
+
+    Page<Inquiry> list = new PageImpl<>(List.of(pending));
+
+    when(inquiryRepository.findInquiryList(anyString(), any())).thenReturn(list);
+
+    // when
+    Page<ListResponse> inquiryList = inquiryService.getInquiryList("", pageable);
+    List<ListResponse> content = inquiryList.getContent();
+
+    // then
+    assertThat(inquiryList.getTotalPages()).isEqualTo(1);
+    assertThat(inquiryList.getSize()).isEqualTo(1);
+    assertThat(inquiryList.getTotalElements()).isEqualTo(1);
+    assertThat(content.size()).isEqualTo(1);
+    assertThat(content.getFirst().getTitle()).isEqualTo("title1");
+    assertThat(content.getFirst().getStatus()).isEqualTo(InquiryStatus.PENDING);
+  }
+
+  @Test
+  @DisplayName("문의 정보 조회")
+  void getInquiryInfo() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Inquiry pending = Inquiry.builder()
+        .id(1L)
+        .user(user).title("title1").content("content1")
+        .status(InquiryStatus.PENDING).build();
+
+    when(inquiryRepository.findById(anyLong())).thenReturn(Optional.of(pending));
+
+    // when
+    DetailResponse inquiryInfo = inquiryService.getInquiryInfo(1L);
+
+    // then
+    assertThat(inquiryInfo.getInquiryId()).isEqualTo(1L);
+    assertThat(inquiryInfo.getTitle()).isEqualTo(pending.getTitle());
+    assertThat(inquiryInfo.getAnswer()).isEqualTo(pending.getAnswer());
+    assertThat(inquiryInfo.getContent()).isEqualTo(pending.getContent());
+    assertThat(inquiryInfo.getStatus()).isEqualTo(pending.getStatus());
+    assertThat(inquiryInfo.getCreatedAt()).isEqualTo(pending.getCreatedAt());
+    assertThat(inquiryInfo.getUpdatedAt()).isEqualTo(pending.getUpdatedAt());
+  }
+
+}

--- a/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
@@ -22,7 +22,9 @@ import com.zerobase.babdeusilbun.repository.InquiryImageRepository;
 import com.zerobase.babdeusilbun.repository.InquiryRepository;
 import com.zerobase.babdeusilbun.repository.UserRepository;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -147,7 +149,8 @@ class InquiryServiceTest {
     Page<InquiryImage> page = new PageImpl<>(list, pageable, 3);
 
     when(inquiryRepository.findById(anyLong())).thenReturn(Optional.of(inquiry));
-    when(inquiryImageRepository.findAllByInquiryOrderBySequence(inquiry, pageable)).thenReturn(page);
+    when(inquiryImageRepository.findAllByInquiryOrderBySequence(inquiry, pageable)).thenReturn(
+        page);
 
     // when
     Page<InquiryImageDto> inquiryImageList = inquiryService.getInquiryImageList(1L, pageable);
@@ -163,6 +166,48 @@ class InquiryServiceTest {
     assertThat(content.getFirst().getUrl()).isEqualTo(image1.getUrl());
     assertThat(content.get(2).getUrl()).isEqualTo(image2.getUrl());
     assertThat(content.getLast().getUrl()).isEqualTo(image3.getUrl());
+  }
+
+  @Test
+  @DisplayName("문의 이미지 순서 변경")
+  void updateImageSequence() throws Exception {
+    // given
+    User user = User.builder().id(1L).email("test").build();
+    CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+    Inquiry inquiry = Inquiry.builder().id(1L).user(user).build();
+
+    InquiryImage image1 = InquiryImage.builder().id(1L).inquiry(inquiry).url("1").sequence(1).build();
+    InquiryImage image2 = InquiryImage.builder().id(2L).inquiry(inquiry).url("2").sequence(2).build();
+    InquiryImage image3 = InquiryImage.builder().id(3L).inquiry(inquiry).url("3").sequence(3).build();
+    InquiryImage image4 = InquiryImage.builder().id(4L).inquiry(inquiry).url("4").sequence(4).build();
+    InquiryImage image5 = InquiryImage.builder().id(5L).inquiry(inquiry).url("5").sequence(5).build();
+    List<InquiryImage> imageList = new ArrayList<>();
+    imageList.add(image1);
+    imageList.add(image2);
+    imageList.add(image3);
+    imageList.add(image4);
+    imageList.add(image5);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(inquiryRepository.findById(1L)).thenReturn(Optional.of(inquiry));
+//    when(inquiryImageRepository.findById(1L)).thenReturn(Optional.of(image1));
+    when(inquiryImageRepository.findById(2L)).thenReturn(Optional.of(image2));
+//    when(inquiryImageRepository.findById(3L)).thenReturn(Optional.of(image3));
+//    when(inquiryImageRepository.findById(4L)).thenReturn(Optional.of(image4));
+//    when(inquiryImageRepository.findById(5L)).thenReturn(Optional.of(image5));
+    when(inquiryImageRepository.findAllByInquiry(any())).thenReturn(imageList);
+
+    // when
+    inquiryService.updateImageSequence(customUserDetails, 1L, 2L, 4);
+
+    // then
+    assertThat(image1.getSequence()).isEqualTo(1);
+    assertThat(image2.getSequence()).isEqualTo(4);
+    assertThat(image3.getSequence()).isEqualTo(2);
+    assertThat(image4.getSequence()).isEqualTo(3);
+    assertThat(image5.getSequence()).isEqualTo(5);
+
   }
 
 }

--- a/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
@@ -4,15 +4,25 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.zerobase.babdeusilbun.component.ImageComponent;
 import com.zerobase.babdeusilbun.domain.Inquiry;
+import com.zerobase.babdeusilbun.domain.InquiryImage;
 import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.enums.InquiryStatus;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.DetailResponse;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.Request;
 import com.zerobase.babdeusilbun.inquiry.service.impl.InquiryServiceImpl;
+import com.zerobase.babdeusilbun.repository.InquiryImageRepository;
 import com.zerobase.babdeusilbun.repository.InquiryRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -26,6 +36,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class InquiryServiceTest {
@@ -34,6 +46,12 @@ class InquiryServiceTest {
   private InquiryServiceImpl inquiryService;
   @Mock
   private InquiryRepository inquiryRepository;
+  @Mock
+  private InquiryImageRepository inquiryImageRepository;
+  @Mock
+  private ImageComponent imageComponent;
+  @Mock
+  private UserRepository userRepository;
 
   @Test
   @DisplayName("문의 목록 조회")
@@ -89,6 +107,31 @@ class InquiryServiceTest {
     assertThat(inquiryInfo.getStatus()).isEqualTo(pending.getStatus());
     assertThat(inquiryInfo.getCreatedAt()).isEqualTo(pending.getCreatedAt());
     assertThat(inquiryInfo.getUpdatedAt()).isEqualTo(pending.getUpdatedAt());
+  }
+
+  @Test
+  @DisplayName("문의 게시글 작성")
+  void createInquiry() throws Exception {
+    // given
+    User user = User.builder().id(1L).email("test").build();
+    CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+    Request request = Request.builder()
+        .title("title request")
+        .content("content request")
+        .build();
+
+    List<String> imageUrlList = List.of("url1", "url2");
+    when(imageComponent.uploadImageList(any(), anyString())).thenReturn(imageUrlList);
+    when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+
+    // when
+    inquiryService.createInquiry(customUserDetails, request, new ArrayList<>());
+
+    // then
+    verify(inquiryImageRepository, times(1)).saveAll(any());
+    verify(inquiryRepository, times(1)).save(any());
+    verify(userRepository, times(1)).findById(1L);
   }
 
 }

--- a/src/test/java/com/zerobase/babdeusilbun/meeting/service/MeetingServiceApiTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/meeting/service/MeetingServiceApiTest.java
@@ -8,15 +8,18 @@ import com.zerobase.babdeusilbun.domain.Meeting;
 import com.zerobase.babdeusilbun.domain.Purchase;
 import com.zerobase.babdeusilbun.domain.PurchasePayment;
 import com.zerobase.babdeusilbun.domain.Store;
+import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.dto.DeliveryAddressDto;
 import com.zerobase.babdeusilbun.dto.MeetingDto;
 import com.zerobase.babdeusilbun.dto.MetAddressDto;
 import com.zerobase.babdeusilbun.enums.PurchaseStatus;
+import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.meeting.dto.MeetingRequest;
 import com.zerobase.babdeusilbun.repository.MeetingRepository;
 import com.zerobase.babdeusilbun.repository.PurchasePaymentRepository;
 import com.zerobase.babdeusilbun.repository.PurchaseRepository;
 import com.zerobase.babdeusilbun.repository.StoreRepository;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
@@ -28,7 +31,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -205,8 +207,7 @@ class MeetingServiceApiTest {
   @DisplayName("모임 생성")
   void createMeeting() {
 
-    UserDetails userDetails = new User("testuser@test.com", "",
-        List.of(new SimpleGrantedAuthority("user")));
+    CustomUserDetails userDetails = new CustomUserDetails(new User());
 
     LocalDateTime now = LocalDateTime.now();
     DeliveryAddressDto deliveryAddressDto = DeliveryAddressDto.builder()


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
문의 게시판에 문의 게시글 등록 삭제 기능을 구현했습니다.
게시글 작성 시 등록한 이미지가 S3에 저장되게 했습니다.
이미지의 순서를 변경 가능하게 하였습니다

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
    - mockito를 이용한 테스트
    - mocking을 위한 list 작성 시 List.of()로 리스트를 만들어 불변객체 관련된 이슈가 있었습니다 -> new ArrayList()로 문제 해결
- [ ] API 테스트 