### PR TITLE
feature: 상점 등록 기능 생성 및 구현, 관련 테스트코드 구현

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/config/CustomDataInitializer.java
+++ b/src/main/java/com/zerobase/babdeusilbun/config/CustomDataInitializer.java
@@ -22,7 +22,7 @@ public class CustomDataInitializer {
   private DataSource dataSource;
   @Autowired
   private JdbcTemplate jdbcTemplate;
-  private final List<String> schemas = List.of("school", "major");
+  private final List<String> schemas = List.of("school", "major", "category");
 
   @Bean
   @Transactional

--- a/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
@@ -1,0 +1,45 @@
+package com.zerobase.babdeusilbun.controller;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
+
+import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.StoreService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class StoreController {
+  private final StoreService storeService;
+
+  /**
+   * 상점 등록
+   */
+  @PreAuthorize("hasRole('ENTREPRENEUR')")
+  @PostMapping(value = "/businesses/stores",
+      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<?> createStore(
+      @AuthenticationPrincipal CustomUserDetails entrepreneur,
+      @RequestPart(value = "files", required = false) List<MultipartFile> images,
+      @RequestPart(value = "request") CreateRequest request) {
+    int uploadSuccessImageCount = storeService.createStore(entrepreneur.getId(), images, request);
+
+    if (images != null && images.size() != uploadSuccessImageCount) {
+      return ResponseEntity.status(PARTIAL_CONTENT).build();
+    }
+
+    return ResponseEntity.status(CREATED).build();
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/domain/Store.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/Store.java
@@ -44,10 +44,10 @@ public class Store extends BaseEntity{
   private String description;
 
   @Column(nullable = false)
-  private Long minOrderAmount;
+  private Long minPurchaseAmount;
 
   @Column(nullable = false)
-  private Integer deliveryPrice;
+  private Long deliveryPrice;
 
   @Column(nullable = false)
   private Integer minDeliveryTime;
@@ -72,7 +72,4 @@ public class Store extends BaseEntity{
   private LocalTime closeTime;
 
   private LocalDateTime deletedAt;
-
-
-
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/AddressDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/AddressDto.java
@@ -4,12 +4,14 @@ import com.zerobase.babdeusilbun.domain.Address;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@EqualsAndHashCode
 public class AddressDto {
 
   private String postal;
@@ -24,4 +26,11 @@ public class AddressDto {
         .build();
   }
 
+  public Address toEntity() {
+    return Address.builder()
+        .postal(postal)
+        .streetAddress(streetAddress)
+        .detailAddress(detailAddress)
+        .build();
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/MeetingDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/MeetingDto.java
@@ -2,7 +2,6 @@ package com.zerobase.babdeusilbun.dto;
 
 import com.zerobase.babdeusilbun.enums.MeetingStatus;
 import com.zerobase.babdeusilbun.enums.PurchaseType;
-import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
@@ -35,7 +34,7 @@ public class MeetingDto {
   private DeliveryAddressDto deliveryAddress;
   private MetAddressDto metAddress;
 
-  private Integer deliveryFee;
+  private Long deliveryFee;
   private LocalDateTime deliveredAt;
 
   private MeetingStatus status;

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
@@ -1,0 +1,104 @@
+package com.zerobase.babdeusilbun.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.domain.Store;
+import com.zerobase.babdeusilbun.domain.StoreImage;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+public class StoreDto {
+  @Data
+  @Builder
+  public static class Information {
+    private Long storeId;
+    private Long entrepreneurId;
+    private String name;
+    private Page<StoreImageDto> image;
+    private String description;
+    private long minPurchasePrice;
+    private String deliveryTimeRange;
+    private long deliveryPrice;
+    private AddressDto address;
+    private String phoneNumber;
+    private LocalTime openTime;
+    private LocalTime closeTime;
+
+    public static Information fromEntity(Store store, Page<StoreImageDto> image) {
+      return Information.builder()
+          .storeId(store.getId())
+          .entrepreneurId(store.getEntrepreneur().getId())
+          .name(store.getName())
+          .image(image)
+          .description(store.getDescription())
+          .minPurchasePrice(store.getMinPurchaseAmount())
+          .deliveryTimeRange(store.getMinDeliveryTime() + "분 ~ " + store.getMaxDeliveryTime() + "분")
+          .deliveryPrice(store.getDeliveryPrice())
+          .address(AddressDto.fromEntity(store.getAddress()))
+          .phoneNumber(store.getPhoneNumber())
+          .openTime(store.getOpenTime())
+          .closeTime(store.getCloseTime())
+          .build();
+    }
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  public static class CreateRequest {
+    private String name;
+    private String description;
+    private long minPurchasePrice;
+    private int minDeliveryTime;
+    private int maxDeliveryTime;
+    private long deliveryPrice;
+    private AddressDto address;
+    private String phoneNumber;
+    @Schema(type = "string", pattern = "HH:mm")
+    private LocalTime openTime;
+    @Schema(type = "string", pattern = "HH:mm")
+    private LocalTime closeTime;
+
+    public Store toEntity(Entrepreneur entrepreneur) {
+      return Store.builder()
+          .name(name)
+          .entrepreneur(entrepreneur)
+          .description(description)
+          .minPurchaseAmount(minPurchasePrice)
+          .minDeliveryTime(minDeliveryTime)
+          .maxDeliveryTime(maxDeliveryTime)
+          .deliveryPrice(deliveryPrice)
+          .address(address.toEntity())
+          .phoneNumber(phoneNumber)
+          .openTime(openTime)
+          .closeTime(closeTime)
+          .build();
+    }
+  }
+
+  @Data
+  @Builder
+  public static class ImageUrl {
+    private String url;
+    private Integer sequence;
+    @JsonProperty("isRepresentative")
+    private boolean isRepresentative;
+
+    public StoreImage toEntity(Store store) {
+      return StoreImage.builder()
+          .store(store)
+          .url(url)
+          .sequence(sequence)
+          .isRepresentative(isRepresentative)
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -60,6 +60,7 @@ public enum ErrorCode {
 
   // 상점 관련
   STORE_NOT_FOUND(NOT_FOUND, "couldn't find store"),
+  ALREADY_EXIST_STORE(CONFLICT, "already have store which user want to enroll."),
 
   //이메일 인증 관련
   CANNOT_SEND_MAIL_EXCEEDS_MAX_COUNT(BAD_REQUEST,

--- a/src/main/java/com/zerobase/babdeusilbun/repository/EntrepreneurRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/EntrepreneurRepository.java
@@ -9,4 +9,6 @@ public interface EntrepreneurRepository extends JpaRepository<Entrepreneur, Long
   boolean existsByEmail(String email);
 
   Optional<Entrepreneur> findByEmail(String email);
+
+  Optional<Entrepreneur> findByIdAndDeletedAtIsNotNull(Long entrepreneurId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
@@ -1,7 +1,11 @@
 package com.zerobase.babdeusilbun.repository;
 
+import com.zerobase.babdeusilbun.domain.Address;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
 import com.zerobase.babdeusilbun.domain.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
+  boolean existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
+      Entrepreneur entrepreneur, String name, Address address);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
@@ -1,7 +1,6 @@
 package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.User;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByEmail(String email);
 
   Optional<User> findByEmail(String email);
+
+  Optional<User> findByIdAndDeletedAtIsNotNull(Long userId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/security/init/InitData.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/init/InitData.java
@@ -171,13 +171,13 @@ public class InitData {
         .build();
   }
 
-  private Store getTestStore(String storeName, Entrepreneur entrepreneur, int deliveryPrice,
+  private Store getTestStore(String storeName, Entrepreneur entrepreneur, long deliveryPrice,
       long minOrderAmount) {
     return Store.builder()
         .entrepreneur(entrepreneur)
         .name(storeName)
         .description("test store description")
-        .minOrderAmount(minOrderAmount)
+        .minPurchaseAmount(minOrderAmount)
         .deliveryPrice(deliveryPrice)
         .minDeliveryTime(10)
         .maxDeliveryTime(20)

--- a/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
@@ -1,0 +1,9 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StoreService {
+  int createStore(Long entrepreneurId, List<MultipartFile> images, CreateRequest request);
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
@@ -1,0 +1,73 @@
+package com.zerobase.babdeusilbun.service.impl;
+
+import static com.zerobase.babdeusilbun.exception.ErrorCode.ALREADY_EXIST_STORE;
+import static com.zerobase.babdeusilbun.exception.ErrorCode.ENTREPRENEUR_NOT_FOUND;
+import static com.zerobase.babdeusilbun.util.ImageUtility.STORE_IMAGE_FOLDER;
+
+import com.zerobase.babdeusilbun.component.ImageComponent;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.domain.Store;
+import com.zerobase.babdeusilbun.domain.StoreImage;
+import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
+import com.zerobase.babdeusilbun.dto.StoreDto.ImageUrl;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.repository.CategoryRepository;
+import com.zerobase.babdeusilbun.repository.EntrepreneurRepository;
+import com.zerobase.babdeusilbun.repository.SchoolRepository;
+import com.zerobase.babdeusilbun.repository.StoreImageRepository;
+import com.zerobase.babdeusilbun.repository.StoreRepository;
+import com.zerobase.babdeusilbun.service.StoreService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@AllArgsConstructor
+public class StoreServiceImpl implements StoreService {
+  private final EntrepreneurRepository entrepreneurRepository;
+  private final StoreRepository storeRepository;
+  private final StoreImageRepository imageRepository;
+  private final SchoolRepository schoolRepository;
+  private final CategoryRepository categoryRepository;
+  private final ImageComponent imageComponent;
+
+  @Override
+  @Transactional
+  public int createStore(Long entrepreneurId, List<MultipartFile> images, CreateRequest request) {
+    Entrepreneur entrepreneur = entrepreneurRepository
+        .findById(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+
+    if (storeRepository.existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
+        entrepreneur, request.getName(), request.getAddress().toEntity())
+    ) {
+      throw new CustomException(ALREADY_EXIST_STORE);
+    }
+
+    Store store = request.toEntity(entrepreneur);
+    storeRepository.save(store);
+
+    List<StoreImage> uploadImageList = new ArrayList<>();
+    AtomicInteger sequence = new AtomicInteger();
+
+    imageComponent.uploadImageList(images, STORE_IMAGE_FOLDER).forEach(url ->
+      uploadImageList.add(
+          ImageUrl.builder()
+              .url(url)
+              .isRepresentative(sequence.get() == 0)
+              .sequence(sequence.getAndIncrement())
+              .build()
+              .toEntity(store)
+      )
+    );
+
+    if (!uploadImageList.isEmpty()) {
+      imageRepository.saveAll(uploadImageList);
+    }
+
+    return uploadImageList.size();
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
@@ -39,7 +39,7 @@ public class StoreServiceImpl implements StoreService {
   @Transactional
   public int createStore(Long entrepreneurId, List<MultipartFile> images, CreateRequest request) {
     Entrepreneur entrepreneur = entrepreneurRepository
-        .findById(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+        .findByIdAndDeletedAtIsNotNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
 
     if (storeRepository.existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
         entrepreneur, request.getName(), request.getAddress().toEntity())

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
@@ -33,7 +33,7 @@ public class UserServiceImpl implements UserService {
   @Override
   @Transactional
   public UpdateRequest updateProfile(Long userId, MultipartFile image, UpdateRequest request) {
-    User user = userRepository.findById(userId)
+    User user = userRepository.findByIdAndDeletedAtIsNotNull(userId)
         .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
     updateSchool(user, request);

--- a/src/main/resources/category.sql
+++ b/src/main/resources/category.sql
@@ -1,0 +1,18 @@
+ALTER TABLE category
+MODIFY created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+MODIFY updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+--매장이 필터되는 카테고리
+INSERT INTO category (name) VALUES
+('족발·보쌈'),
+('찜·탕·찌개'),
+('돈까스·회·일식'),
+('피자'),
+('고기·구이'),
+('치킨'),
+('중식'),
+('아시안'),
+('카페·디저트'),
+('패스트푸드'),
+('분식')
+;

--- a/src/test/java/com/zerobase/babdeusilbun/controller/StoreControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/StoreControllerTest.java
@@ -1,0 +1,134 @@
+package com.zerobase.babdeusilbun.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.babdeusilbun.dto.AddressDto;
+import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.StoreService;
+import com.zerobase.babdeusilbun.util.TestEntrepreneurUtility;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+
+@WebMvcTest(StoreController.class)
+public class StoreControllerTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private StoreService storeService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private CustomUserDetails testEntrepreneur;
+  private final CreateRequest createRequest = CreateRequest.builder()
+      .name("Test Store")
+        .description("A test store")
+        .minPurchasePrice(10000L)
+        .minDeliveryTime(30)
+        .maxDeliveryTime(60)
+        .deliveryPrice(2500L)
+        .address(new AddressDto("00000", "도로명주소", "상세주소"))
+      .phoneNumber("01012345678")
+        .openTime(LocalTime.of(9, 0))
+      .closeTime(LocalTime.of(21, 0))
+      .build();
+
+  @BeforeEach
+  void setUp() {
+    //로그인 정보 세팅
+    testEntrepreneur = TestEntrepreneurUtility.createTestEntrepreneur();
+
+    SecurityContextHolder.getContext().setAuthentication(
+        new UsernamePasswordAuthenticationToken(testEntrepreneur, null, testEntrepreneur.getAuthorities())
+    );
+  }
+
+  @DisplayName("상점 등록 컨트롤러 테스트(완전 성공)")
+  @Test
+  void createStoreSuccess() throws Exception {
+    //given
+    MockMultipartFile request = new MockMultipartFile(
+        "request", "request", "application/json",
+        objectMapper.writeValueAsString(createRequest).getBytes());
+
+    MockMultipartFile image1 = new MockMultipartFile(
+        "files", "image1.png", "image/png", "1".getBytes());
+
+    MockMultipartFile image2 = new MockMultipartFile(
+        "files", "image2.png", "image/png", "2".getBytes());
+
+    List<MultipartFile> images = List.of(image1, image2);
+
+    //when
+    when(storeService.createStore(eq(testEntrepreneur.getId()), eq(images), eq(createRequest)))
+        .thenReturn(2);
+
+    //then
+    mockMvc.perform(multipart(HttpMethod.POST, "/api/businesses/stores")
+            .file(image1)
+            .file(image2)
+            .file(request)
+            .with(csrf())
+            .with(httpRequest -> {
+              httpRequest.setMethod("POST");
+              return httpRequest;
+            }))
+        .andDo(print())
+        .andExpect(status().isCreated());
+  }
+
+  @DisplayName("상점 등록 컨트롤러 테스트(부분 성공)")
+  @Test
+  void createStorePartialSuccess() throws Exception {
+    //given
+
+
+    MockMultipartFile request = new MockMultipartFile(
+        "request", "request", "application/json",
+        objectMapper.writeValueAsString(createRequest).getBytes());
+
+    MockMultipartFile image1 = new MockMultipartFile(
+        "files", "image1.png", "image/png", "1".getBytes());
+
+    MockMultipartFile image2 = new MockMultipartFile(
+        "files", "image2.png", "image/png", "2".getBytes());
+
+    List<MultipartFile> images = List.of(image1, image2);
+
+    //when
+    when(storeService.createStore(eq(testEntrepreneur.getId()), eq(images), eq(createRequest)))
+        .thenReturn(1);
+
+    //then
+    mockMvc.perform(multipart("/api/businesses/stores")
+            .file(request)
+            .file(image1)
+            .file(image2)
+            .with(csrf())
+            .with(httpRequest -> {
+              httpRequest.setMethod("POST");
+              return httpRequest;
+            }))
+        .andExpect(status().isPartialContent());
+  }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/service/StoreServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/StoreServiceTest.java
@@ -83,7 +83,7 @@ public class StoreServiceTest {
     List<MultipartFile> images = List.of();
     Store expected = createRequest.toEntity(entrepreneur);
 
-    when(entrepreneurRepository.findById(eq(TestEntrepreneurUtility.getEntrepreneur().getId())))
+    when(entrepreneurRepository.findByIdAndDeletedAtIsNotNull(eq(TestEntrepreneurUtility.getEntrepreneur().getId())))
         .thenReturn(Optional.of(entrepreneur));
     when(storeRepository.existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
         eq(entrepreneur), eq(createRequest.getName()), any()))
@@ -121,7 +121,7 @@ public class StoreServiceTest {
     Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
     List<MultipartFile> images = List.of();
 
-    when(entrepreneurRepository.findById(eq(entrepreneur.getId()))).thenReturn(Optional.of(entrepreneur));
+    when(entrepreneurRepository.findByIdAndDeletedAtIsNotNull(eq(entrepreneur.getId()))).thenReturn(Optional.of(entrepreneur));
     when(storeRepository.existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
         eq(entrepreneur), eq(createRequest.getName()), any())).thenReturn(true);
 
@@ -140,7 +140,7 @@ public class StoreServiceTest {
     Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
     List<MultipartFile> images = List.of();
 
-    when(entrepreneurRepository.findById(any())).thenReturn(Optional.empty());
+    when(entrepreneurRepository.findByIdAndDeletedAtIsNotNull(any())).thenReturn(Optional.empty());
 
     // when & then
     CustomException exception = assertThrows(CustomException.class, () -> {

--- a/src/test/java/com/zerobase/babdeusilbun/service/StoreServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/StoreServiceTest.java
@@ -1,0 +1,152 @@
+package com.zerobase.babdeusilbun.service;
+
+import static com.zerobase.babdeusilbun.exception.ErrorCode.ALREADY_EXIST_STORE;
+import static com.zerobase.babdeusilbun.exception.ErrorCode.ENTREPRENEUR_NOT_FOUND;
+import static com.zerobase.babdeusilbun.util.ImageUtility.STORE_IMAGE_FOLDER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import com.zerobase.babdeusilbun.component.ImageComponent;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.domain.Store;
+import com.zerobase.babdeusilbun.domain.StoreImage;
+import com.zerobase.babdeusilbun.dto.AddressDto;
+import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.repository.CategoryRepository;
+import com.zerobase.babdeusilbun.repository.EntrepreneurRepository;
+import com.zerobase.babdeusilbun.repository.SchoolRepository;
+import com.zerobase.babdeusilbun.repository.StoreImageRepository;
+import com.zerobase.babdeusilbun.repository.StoreRepository;
+import com.zerobase.babdeusilbun.service.impl.StoreServiceImpl;
+import com.zerobase.babdeusilbun.util.TestEntrepreneurUtility;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class StoreServiceTest {
+  @Mock
+  private EntrepreneurRepository entrepreneurRepository;
+
+  @Mock
+  private StoreRepository storeRepository;
+
+  @Mock
+  private StoreImageRepository imageRepository;
+
+  @Mock
+  private SchoolRepository schoolRepository;
+
+  @Mock
+  private CategoryRepository categoryRepository;
+
+  @Mock
+  private ImageComponent imageComponent;
+
+  @InjectMocks
+  private StoreServiceImpl storeService;
+
+  private final CreateRequest createRequest = CreateRequest.builder()
+      .name("가짜 상점")
+      .description("가짜 상점입니다.")
+      .minPurchasePrice(10000L)
+      .minDeliveryTime(30)
+      .maxDeliveryTime(60)
+      .deliveryPrice(1000L)
+      .address(new AddressDto("00000", "도로명주소", "상세주소"))
+      .phoneNumber("01012345678")
+      .openTime(LocalTime.of(9, 0))
+      .closeTime(LocalTime.of(21, 0))
+      .build();
+
+  @DisplayName("가게 생성 성공 사례 테스트")
+  @Test
+  void createStoreSuccess() {
+    // given
+    Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
+    List<MultipartFile> images = List.of();
+    Store expected = createRequest.toEntity(entrepreneur);
+
+    when(entrepreneurRepository.findById(eq(TestEntrepreneurUtility.getEntrepreneur().getId())))
+        .thenReturn(Optional.of(entrepreneur));
+    when(storeRepository.existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
+        eq(entrepreneur), eq(createRequest.getName()), any()))
+        .thenReturn(false);
+    when(imageComponent.uploadImageList(eq(images), eq(STORE_IMAGE_FOLDER))).thenReturn(List.of("url1", "url2"));
+
+    // when
+    int uploadedImageCount = storeService.createStore(entrepreneur.getId(), images, createRequest);
+
+    // then
+    ArgumentCaptor<Store> storeCaptor = ArgumentCaptor.forClass(Store.class);
+    ArgumentCaptor<List<StoreImage>> storeImagesCaptor = ArgumentCaptor.forClass(List.class);
+
+    verify(storeRepository, times(1)).save(storeCaptor.capture());
+    verify(imageRepository, times(1)).saveAll(storeImagesCaptor.capture());
+
+    assertEquals(2, uploadedImageCount);
+    List<StoreImage> savedImages = storeImagesCaptor.getValue();
+    assertEquals("url1", savedImages.get(0).getUrl());
+    assertTrue(savedImages.get(0).getIsRepresentative());
+    assertEquals("url2", savedImages.get(1).getUrl());
+    assertFalse(savedImages.get(1).getIsRepresentative());
+
+    assertEquals(
+        expected.getEntrepreneur().getId(), storeCaptor.getValue().getEntrepreneur().getId());
+    assertEquals(expected.getName(), storeCaptor.getValue().getName());
+    assertEquals(AddressDto.fromEntity(expected.getAddress()),
+        AddressDto.fromEntity(storeCaptor.getValue().getAddress()));
+  }
+
+  @DisplayName("가게 생성 실패(중복된 가게 등록 요청)")
+  @Test
+  void createStoreFailedAlreadyExists() {
+    // given
+    Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
+    List<MultipartFile> images = List.of();
+
+    when(entrepreneurRepository.findById(eq(entrepreneur.getId()))).thenReturn(Optional.of(entrepreneur));
+    when(storeRepository.existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
+        eq(entrepreneur), eq(createRequest.getName()), any())).thenReturn(true);
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      storeService.createStore(entrepreneur.getId(), images, createRequest);
+    });
+
+    assertEquals(ALREADY_EXIST_STORE, exception.getErrorCode());
+  }
+
+  @DisplayName("가게 생성 실패(사업가 미존재)")
+  @Test
+  void createStoreFailedEntrepreneurNotFound() {
+    // given
+    Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
+    List<MultipartFile> images = List.of();
+
+    when(entrepreneurRepository.findById(any())).thenReturn(Optional.empty());
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      storeService.createStore(entrepreneur.getId(), images, createRequest);
+    });
+
+    assertEquals(ENTREPRENEUR_NOT_FOUND, exception.getErrorCode());
+  }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/UserServiceTest.java
@@ -56,7 +56,7 @@ public class UserServiceTest {
 
     String originImage = user.getImage();
 
-    when(userRepository.findById(eq(user.getId()))).thenReturn(java.util.Optional.of(user));
+    when(userRepository.findByIdAndDeletedAtIsNotNull(eq(user.getId()))).thenReturn(java.util.Optional.of(user));
     when(schoolRepository.findById(eq(request.getSchoolId()))).thenReturn(java.util.Optional.of(school));
     when(majorRepository.findById(eq(request.getMajorId()))).thenReturn(java.util.Optional.of(major));
     when(passwordEncoder.encode(eq(request.getPassword()))).thenReturn("encodedPassword");

--- a/src/test/java/com/zerobase/babdeusilbun/util/TestEntrepreneurUtility.java
+++ b/src/test/java/com/zerobase/babdeusilbun/util/TestEntrepreneurUtility.java
@@ -1,0 +1,29 @@
+package com.zerobase.babdeusilbun.util;
+
+import com.zerobase.babdeusilbun.domain.Address;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+
+public class TestEntrepreneurUtility {
+  private final static Entrepreneur entrepreneur = Entrepreneur.builder()
+      .id(1L)
+      .email("entrepreneur@test.com")
+      .password("password")
+      .name("가짜 사업가")
+      .phoneNumber("00000000000")
+      .businessNumber("0000000000")
+      .address(Address.builder()
+          .postal("00000")
+          .streetAddress("도로명주소")
+          .detailAddress("상세주소")
+          .build())
+      .build();
+
+  public static CustomUserDetails createTestEntrepreneur() {
+    return new CustomUserDetails(entrepreneur);
+  }
+
+  public static Entrepreneur getEntrepreneur() {
+    return entrepreneur;
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 사업가가 상점을 등록하는 api가 필요했습니다.
- 상점을 분류하는 카테고리에 대한 정보가 미리 있어야하는데, 빈 채로 있었습니다.
- AddressDto에서 안의 내용이 모두 같아도 같은 객체로 인식하지 못했습니다.
- Store 엔티티에 Purchase가 아닌 Order로 기재된 채 남아있는 필드가 있었습니다.
- 가격은 Long 타입인데 Integer로 적용된 필드가 있었습니다.
- 탈퇴한 이용자는 이용자를 불러올 때 제외해야하는데, 관련 조건문이 없었습니다.
- 사업가를 테스트하기위한 기본 정보를 저장하는 Utility가 없었습니다.

**TO-BE**
- 사업가가 상점을 등록하는 api를 생성, 구현했습니다.
  - 상점은 등록하였으나 이미지 업로드가 요청만큼 되지 않은 경우 206 status가 반환되게 하였습니다.
- 관련해 필요한 DTO를 생성했습니다.
- 상점을 분류하는 카테고리를 등록하기 위해 미리 데이터를 적재하는 sql문을 작성했습니다.
- AddressDto 안의 내용이 모두 같으면 같은 객체로 인식할 수 있게 어노테이션을 이용하였습니다.
- Store 엔티티의 Order를 Purchase로 변경하였습니다.
- 가격인데 Integer인 필드를 Long 타입으로 변환하였습니다.
- 탈퇴한 이용자는 제외될 수 있게 조건문을 작성하였습니다.
- 사업가를 테스트하기위한 기본 정보를 저장하는 Utility를 작성했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 컨트롤러 테스트
    - 실제 서비스 호출 없이 테스트할 수 있도록 `StoreService`에 대해 Mock 설정.
    - `SecurityContextHolder`를 이용하여 테스트 유저 인증 정보를 세팅.
    
      <details>
        <summary>가게 생성 성공 테스트 과정</summary>

        - `CreateRequest` 객체를 생성하여 가게 생성 요청.
        - `StoreService.createStore` 메서드를 Mocking하여 테스트 요청 시 예상 가능한 가게 데이터를 반환하도록 설정.
        - 테스트는 `/api/stores` 엔드포인트에 POST 요청을 보내 반환된 응답의 HTTP 상태 코드와 JSON 응답 검증.
      </details>
      
  - 서비스 테스트
    - 실제 DB와 연동하지 않고, 데이터 유효성을 검증하기 위해 `EntrepreneurRepository`, `StoreRepository`, `ImageComponent` 인터페이스를 Mocking.
  
      <details>
        <summary>가게 생성 서비스 테스트 과정</summary>

        - `Entrepreneur` 객체와 관련 데이터 (`Store`, `StoreImage`)를 Mock으로 설정하고, `StoreService.createStore` 메서드 호출 시 예상되는 결과를 반환하도록 설정.
        - 요청된 가게 이름, 주소, 이미지 등이 제대로 저장되었는지 검증.
        - `ArgumentCaptor`를 사용하여 실제로 저장된 `Store` 객체의 필드 값과, `StoreImage` 객체의 URL이 예상대로인지 검증.
      </details>

- [x] API 테스트