### PR TITLE
fix : 사업자 토큰 생성시 이메일 수식어 관련 오타 수정

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
@@ -134,7 +134,7 @@ public class SignServiceImpl implements SignService {
     verifyWithdrawalEntrepreneur(findEntrepreneur);
     verifyPassword(password, findEntrepreneur.getPassword());
 
-    return jwtComponent.createToken(ROLE_ENTREPRENEUR + "_" + email, ROLE_ENTREPRENEUR.name());
+    return jwtComponent.createToken(ROLE_ENTREPRENEUR.name() + "_" + email, ROLE_ENTREPRENEUR.name());
   }
 
   @Override


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 사업자 토큰 생성시 이메일 이름을 정하는 부분에서 enum값에 .name()이 붙여지지 않은 것을 발견하였습니다.

**TO-BE**
- 버그 방지를 위해 해당 부분을 수정하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 