### PR TITLE
feature: 학과 검색 api 생성

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/MajorController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/MajorController.java
@@ -1,0 +1,29 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.zerobase.babdeusilbun.service.MajorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MajorController {
+
+   private final MajorService majorService;
+
+    /**
+     * 학과 검색
+     */
+    @GetMapping("/majors")
+    public ResponseEntity<?> searchSchoolAndCampus(
+            @RequestParam(name = "majorName", required = false, defaultValue = "") String majorName,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+        return ResponseEntity.ok(majorService.searchMajor(majorName, page, size));
+    }
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/dto/MajorDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/MajorDto.java
@@ -1,0 +1,48 @@
+package com.zerobase.babdeusilbun.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.zerobase.babdeusilbun.domain.Major;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+public class MajorDto {
+    @Data
+    @Builder
+    public static class Principal {
+        private Long id;
+        private String name;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static MajorDto.Principal fromEntity(Major major) {
+            return MajorDto.Principal.builder()
+                    .id(major.getId())
+                    .name(major.getName())
+                    .createdAt(major.getCreatedAt())
+                    .updatedAt(major.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    public static class Information {
+        private Long id;
+        private String name;
+
+        public static SchoolDto.Information fromEntity(Major major) {
+            return SchoolDto.Information.builder()
+                    .id(major.getId())
+                    .name(major.getName())
+                    .build();
+        }
+
+        @QueryProjection
+        public Information(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/repository/MajorRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MajorRepository.java
@@ -1,7 +1,11 @@
 package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Major;
+import com.zerobase.babdeusilbun.dto.SchoolDto;
+import com.zerobase.babdeusilbun.repository.custom.CustomMajorRepository;
+import com.zerobase.babdeusilbun.repository.custom.CustomSchoolRepository;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MajorRepository extends JpaRepository<Major, Long> {
+public interface MajorRepository extends JpaRepository<Major, Long>, CustomMajorRepository {
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomMajorRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomMajorRepository.java
@@ -1,0 +1,8 @@
+package com.zerobase.babdeusilbun.repository.custom;
+
+import com.zerobase.babdeusilbun.dto.MajorDto;
+import org.springframework.data.domain.Page;
+
+public interface CustomMajorRepository {
+    Page<MajorDto.Information> searchMajorNameByKeywords(String[] keywords, int page, int size);
+}

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomMajorRepositoryImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomMajorRepositoryImpl.java
@@ -1,0 +1,87 @@
+package com.zerobase.babdeusilbun.repository.custom.impl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.babdeusilbun.domain.QMajor;
+import com.zerobase.babdeusilbun.dto.QMajorDto_Information;
+import com.zerobase.babdeusilbun.dto.MajorDto.Information;
+import com.zerobase.babdeusilbun.repository.custom.CustomMajorRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomMajorRepositoryImpl implements CustomMajorRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QMajor major = QMajor.major;
+
+    @Override
+    public Page<Information> searchMajorNameByKeywords(String[] keywords, int page, int size) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        for (String keyword: keywords) {
+            if (keyword == null || keyword.isBlank()) continue;
+
+            builder.and(Expressions.stringTemplate("replace({0}, ' ', '')", major.name).contains(keyword));
+        }
+
+        Long count = jpaQueryFactory
+                .select(major.id.count())
+                .from(major)
+                .where(builder)
+                .fetchOne();
+
+        if (count == null || count == 0L) {
+            return new PageImpl<>(new ArrayList<>(), PageRequest.of(page, Math.max(size, 1)), 0);
+        }
+
+        size = (size <= 0) ? count.intValue() : size;
+        page = Math.min(page, ((int) Math.ceil((double) count / size))-1);
+
+        Sort sort = Sort.by(Order.asc("name"));
+        List<OrderSpecifier<?>> orderSpecifiers = getOrderSpecifiers(sort);
+
+        List<Information> list = jpaQueryFactory
+                .select(new QMajorDto_Information(major.id, major.name))
+                .from(major)
+                .where(builder)
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+                .offset((long) page*size)
+                .limit(size)
+                .fetch();
+
+        return new PageImpl<>(list, PageRequest.of(page, size, sort), count);
+    }
+
+
+    private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+        for (Order order : sort) {
+            OrderSpecifier<?> orderSpecifier = switch (order.getProperty()) {
+                case "name" -> order.isAscending() ?
+                        major.name.asc() : major.name.desc();
+                case "majorId" -> order.isAscending() ?
+                        major.id.asc() : major.id.desc();
+                case "createdAt" -> order.isAscending() ?
+                        major.createdAt.asc() : major.createdAt.desc();
+                case "updatedAt" -> order.isAscending() ?
+                        major.updatedAt.asc() : major.updatedAt.desc();
+                default -> throw new IllegalArgumentException("Unknown sort property: " + order.getProperty());
+            };
+            orderSpecifiers.add(orderSpecifier);
+        }
+        return orderSpecifiers;
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/service/impl/SignServiceImpl.java
@@ -134,7 +134,7 @@ public class SignServiceImpl implements SignService {
     verifyWithdrawalEntrepreneur(findEntrepreneur);
     verifyPassword(password, findEntrepreneur.getPassword());
 
-    return jwtComponent.createToken(ROLE_ENTREPRENEUR + "_" + email, ROLE_ENTREPRENEUR.name());
+    return jwtComponent.createToken(ROLE_ENTREPRENEUR.name() + "_" + email, ROLE_ENTREPRENEUR.name());
   }
 
   @Override

--- a/src/main/java/com/zerobase/babdeusilbun/service/MajorService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/MajorService.java
@@ -1,0 +1,8 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.dto.MajorDto;
+import org.springframework.data.domain.Page;
+
+public interface MajorService {
+    Page<MajorDto.Information> searchMajor(String majorName, int page, int size);
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/MajorServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/MajorServiceImpl.java
@@ -1,0 +1,27 @@
+package com.zerobase.babdeusilbun.service.impl;
+
+import com.zerobase.babdeusilbun.dto.MajorDto.Information;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.exception.ErrorCode;
+import com.zerobase.babdeusilbun.repository.MajorRepository;
+import com.zerobase.babdeusilbun.repository.SchoolRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.MajorService;
+import com.zerobase.babdeusilbun.service.SchoolService;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class MajorServiceImpl implements MajorService {
+    private final MajorRepository majorRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Information> searchMajor(String majorName, int page, int size) {
+        return majorRepository.searchMajorNameByKeywords(majorName.split(" +"), page, size);
+    }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/controller/MajorControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/MajorControllerTest.java
@@ -1,0 +1,65 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.zerobase.babdeusilbun.dto.MajorDto;
+import com.zerobase.babdeusilbun.service.MajorService;
+import com.zerobase.babdeusilbun.service.SchoolService;
+import com.zerobase.babdeusilbun.util.TestUserUtility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(MajorController.class)
+public class MajorControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MajorService majorService;
+
+    @DisplayName("학과 검색 테스트")
+    @WithMockUser
+    @Test
+    void searchMajor() throws Exception {
+        //given
+        MajorDto.Information info = new MajorDto.Information(1L, "가짜 학과");
+        Page<MajorDto.Information> expectedPage = new PageImpl<>(List.of(info));
+
+        //when
+        when(majorService.searchMajor(anyString(), anyInt(), anyInt()))
+                .thenReturn(expectedPage);
+
+        //then
+        mockMvc.perform(get("/api/majors")
+                        .param("majorName", "")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].name").value("가짜 학과"))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.pageable").exists());
+    }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/service/MajorServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/MajorServiceTest.java
@@ -1,0 +1,45 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.dto.MajorDto;
+import com.zerobase.babdeusilbun.repository.MajorRepository;
+import com.zerobase.babdeusilbun.service.impl.MajorServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MajorServiceTest {
+    @Mock
+    private MajorRepository majorRepository;
+
+    @InjectMocks
+    private MajorServiceImpl majorService;
+
+    @DisplayName("학과 검색 서비스 테스트")
+    @Test
+    void searchMajor() {
+        //given
+        int page = 0;
+        int size = 10;
+        String search = "가짜";
+        String[] keywords = search.split(" +");
+        Page<MajorDto.Information> expectedPage = new PageImpl<>(Collections.emptyList());
+
+        //when
+        when(majorRepository.searchMajorNameByKeywords(keywords, page, size)).thenReturn(expectedPage);
+        Page<MajorDto.Information> result = majorService.searchMajor(search, page, size);
+
+        //then
+        assertEquals(expectedPage, result);
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
  - 학과 검색 api가 아직 구현되지 않은 상태였습니다.

**TO-BE**
  - api
    - controller
      - sort가 고정되어있어 명시적으로 page, size를 전달받게 했습니다.
    - service
      - 입력받은 String을 공백 기준으로 나눠, 각 문자열을 모두 학과명에 포함된 값을 가져오도록 하였습니다.
    - repository
      - customMajorRepository를 생성해 필요한 값을 Page<DTO>로 반환하게 하였습니다.
    - dto
      - major 테이블의 엔티티를 그대로 DTO로 옮기는 Principal 객체와 필요 정보만 가져오는 Information 객체로 나누었습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  <details>
    <summary>서비스 테스트</summary>

    - repository 결괏값을 주어줬을 때 서비스단에서 return하는 값이 올바른지 확인
  </details>

  <details>
    <summary>컨트롤러 테스트</summary>

    - HTTP 요청 응답 검증
    - 서비스 호출 검증
    - 보안 검증
    - API 계약 준수 확인
  </details>
- [x] API 테스트 