### PR TITLE
feat : 내 정보 조회 서비스 구현

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/MajorController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/MajorController.java
@@ -1,0 +1,29 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.zerobase.babdeusilbun.service.MajorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MajorController {
+
+   private final MajorService majorService;
+
+    /**
+     * 학과 검색
+     */
+    @GetMapping("/majors")
+    public ResponseEntity<?> searchSchoolAndCampus(
+            @RequestParam(name = "majorName", required = false, defaultValue = "") String majorName,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+        return ResponseEntity.ok(majorService.searchMajor(majorName, page, size));
+    }
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/controller/UserController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/UserController.java
@@ -10,10 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -22,6 +19,16 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserController {
   private final UserService userService;
 
+
+  /**
+   * 내 정보 조회
+   */
+  @PreAuthorize("hasRole('USER')")
+  @GetMapping("/my-page")
+  public ResponseEntity<?> getMyProfile() {
+    UserDto.MyPage myPage= userService.getMyPage();
+    return ResponseEntity.ok(myPage);
+  }
   /**
    * 내 정보 수정
    */

--- a/src/main/java/com/zerobase/babdeusilbun/domain/BankAccount.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/BankAccount.java
@@ -2,6 +2,8 @@ package com.zerobase.babdeusilbun.domain;
 
 import com.zerobase.babdeusilbun.enums.Bank;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class BankAccount {
-
+  @Enumerated(EnumType.STRING)
   private Bank bank;
 
   private String accountOwner;

--- a/src/main/java/com/zerobase/babdeusilbun/dto/MajorDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/MajorDto.java
@@ -1,0 +1,48 @@
+package com.zerobase.babdeusilbun.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.zerobase.babdeusilbun.domain.Major;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+public class MajorDto {
+    @Data
+    @Builder
+    public static class Principal {
+        private Long id;
+        private String name;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static MajorDto.Principal fromEntity(Major major) {
+            return MajorDto.Principal.builder()
+                    .id(major.getId())
+                    .name(major.getName())
+                    .createdAt(major.getCreatedAt())
+                    .updatedAt(major.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    public static class Information {
+        private Long id;
+        private String name;
+
+        public static SchoolDto.Information fromEntity(Major major) {
+            return SchoolDto.Information.builder()
+                    .id(major.getId())
+                    .name(major.getName())
+                    .build();
+        }
+
+        @QueryProjection
+        public Information(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/dto/UserDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/UserDto.java
@@ -1,8 +1,10 @@
 package com.zerobase.babdeusilbun.dto;
 
+import com.zerobase.babdeusilbun.domain.BankAccount;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.zerobase.babdeusilbun.domain.Address;
 
 public class UserDto {
   @Data
@@ -15,5 +17,25 @@ public class UserDto {
     private String phoneNumber;
     private Long schoolId;
     private Long majorId;
+  }
+
+  public interface MyPage {
+    String getName();
+    String getNickname();
+    String getPhoneNumber();
+    String getEmail();
+
+    Long getPoint();
+    String getImage();
+    Long getMeetingCount();
+    String getSchool();
+    String getCampus();
+    String getMajor();
+    Boolean getIsBanned();
+
+    Address getAddress();
+
+    BankAccount getBankAccount();
+
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/MajorRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MajorRepository.java
@@ -1,7 +1,11 @@
 package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Major;
+import com.zerobase.babdeusilbun.dto.SchoolDto;
+import com.zerobase.babdeusilbun.repository.custom.CustomMajorRepository;
+import com.zerobase.babdeusilbun.repository.custom.CustomSchoolRepository;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MajorRepository extends JpaRepository<Major, Long> {
+public interface MajorRepository extends JpaRepository<Major, Long>, CustomMajorRepository {
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
@@ -2,7 +2,10 @@ package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.User;
 import java.util.Optional;
+
+import com.zerobase.babdeusilbun.dto.UserDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -11,4 +14,16 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   Optional<User> findByIdAndDeletedAtIsNotNull(Long userId);
+
+  @Query(value=
+          "select user.email as email, user.name as name, user.nickname as nickname, user.phoneNumber as phoneNumber, " +
+                  "user.bankAccount as bankAccount, user.point as point, user.address as address, user.image as image, user.isBanned as isBanned," +
+                  " ifnull(count(purchase.id), 0) as meetingCount, school.name as school, school.campus as campus, major.name as major \n" +
+                  "from com.zerobase.babdeusilbun.domain.User as user \n" +
+                  "left join com.zerobase.babdeusilbun.domain.Purchase as purchase on user.id = purchase.user.id, \n" +
+                  "com.zerobase.babdeusilbun.domain.School as school, \n" +
+                  "com.zerobase.babdeusilbun.domain.Major as major \n" +
+                  "where user.email = :email and school.id = user.school.id and major.id = user.major.id \n" +
+                  "group by user.id \n")
+  Optional<UserDto.MyPage> findMyPageByEmail(String email);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomMajorRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomMajorRepository.java
@@ -1,0 +1,8 @@
+package com.zerobase.babdeusilbun.repository.custom;
+
+import com.zerobase.babdeusilbun.dto.MajorDto;
+import org.springframework.data.domain.Page;
+
+public interface CustomMajorRepository {
+    Page<MajorDto.Information> searchMajorNameByKeywords(String[] keywords, int page, int size);
+}

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomMajorRepositoryImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomMajorRepositoryImpl.java
@@ -1,0 +1,87 @@
+package com.zerobase.babdeusilbun.repository.custom.impl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.babdeusilbun.domain.QMajor;
+import com.zerobase.babdeusilbun.dto.QMajorDto_Information;
+import com.zerobase.babdeusilbun.dto.MajorDto.Information;
+import com.zerobase.babdeusilbun.repository.custom.CustomMajorRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomMajorRepositoryImpl implements CustomMajorRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QMajor major = QMajor.major;
+
+    @Override
+    public Page<Information> searchMajorNameByKeywords(String[] keywords, int page, int size) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        for (String keyword: keywords) {
+            if (keyword == null || keyword.isBlank()) continue;
+
+            builder.and(Expressions.stringTemplate("replace({0}, ' ', '')", major.name).contains(keyword));
+        }
+
+        Long count = jpaQueryFactory
+                .select(major.id.count())
+                .from(major)
+                .where(builder)
+                .fetchOne();
+
+        if (count == null || count == 0L) {
+            return new PageImpl<>(new ArrayList<>(), PageRequest.of(page, Math.max(size, 1)), 0);
+        }
+
+        size = (size <= 0) ? count.intValue() : size;
+        page = Math.min(page, ((int) Math.ceil((double) count / size))-1);
+
+        Sort sort = Sort.by(Order.asc("name"));
+        List<OrderSpecifier<?>> orderSpecifiers = getOrderSpecifiers(sort);
+
+        List<Information> list = jpaQueryFactory
+                .select(new QMajorDto_Information(major.id, major.name))
+                .from(major)
+                .where(builder)
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+                .offset((long) page*size)
+                .limit(size)
+                .fetch();
+
+        return new PageImpl<>(list, PageRequest.of(page, size, sort), count);
+    }
+
+
+    private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+        for (Order order : sort) {
+            OrderSpecifier<?> orderSpecifier = switch (order.getProperty()) {
+                case "name" -> order.isAscending() ?
+                        major.name.asc() : major.name.desc();
+                case "majorId" -> order.isAscending() ?
+                        major.id.asc() : major.id.desc();
+                case "createdAt" -> order.isAscending() ?
+                        major.createdAt.asc() : major.createdAt.desc();
+                case "updatedAt" -> order.isAscending() ?
+                        major.updatedAt.asc() : major.updatedAt.desc();
+                default -> throw new IllegalArgumentException("Unknown sort property: " + order.getProperty());
+            };
+            orderSpecifiers.add(orderSpecifier);
+        }
+        return orderSpecifiers;
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/MajorService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/MajorService.java
@@ -1,0 +1,8 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.dto.MajorDto;
+import org.springframework.data.domain.Page;
+
+public interface MajorService {
+    Page<MajorDto.Information> searchMajor(String majorName, int page, int size);
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/UserService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/UserService.java
@@ -4,5 +4,8 @@ import com.zerobase.babdeusilbun.dto.UserDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
+
+  UserDto.MyPage getMyPage();
+
   UserDto.UpdateRequest updateProfile(Long userId, MultipartFile image, UserDto.UpdateRequest request);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/MajorServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/MajorServiceImpl.java
@@ -1,0 +1,27 @@
+package com.zerobase.babdeusilbun.service.impl;
+
+import com.zerobase.babdeusilbun.dto.MajorDto.Information;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.exception.ErrorCode;
+import com.zerobase.babdeusilbun.repository.MajorRepository;
+import com.zerobase.babdeusilbun.repository.SchoolRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.MajorService;
+import com.zerobase.babdeusilbun.service.SchoolService;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class MajorServiceImpl implements MajorService {
+    private final MajorRepository majorRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Information> searchMajor(String majorName, int page, int size) {
+        return majorRepository.searchMajorNameByKeywords(majorName.split(" +"), page, size);
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
@@ -7,6 +7,7 @@ import com.zerobase.babdeusilbun.component.ImageComponent;
 import com.zerobase.babdeusilbun.domain.Major;
 import com.zerobase.babdeusilbun.domain.School;
 import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.UserDto;
 import com.zerobase.babdeusilbun.dto.UserDto.UpdateRequest;
 import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.repository.MajorRepository;
@@ -16,6 +17,8 @@ import com.zerobase.babdeusilbun.service.UserService;
 import io.micrometer.common.util.StringUtils;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +32,24 @@ public class UserServiceImpl implements UserService {
   private final MajorRepository majorRepository;
   private final ImageComponent imageComponent;
   private final PasswordEncoder passwordEncoder;
+
+  // 현재 로그인한 사람의 이메일 정보를 가져오는 함수
+  private String getLoginUserEmail() {
+    UserDetails userDetails = (UserDetails) SecurityContextHolder.getContextHolderStrategy()
+            .getContext()
+            .getAuthentication()
+            .getPrincipal();
+
+    int splitIndex = userDetails.getUsername().indexOf("_", 5);
+    return userDetails.getUsername().substring(splitIndex+1);
+  }
+
+  // 내 정보 조회
+  @Override
+  public UserDto.MyPage getMyPage() {
+    return userRepository.findMyPageByEmail(getLoginUserEmail())
+            .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+  }
 
   @Override
   @Transactional

--- a/src/test/java/com/zerobase/babdeusilbun/controller/MajorControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/MajorControllerTest.java
@@ -1,0 +1,65 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.zerobase.babdeusilbun.dto.MajorDto;
+import com.zerobase.babdeusilbun.service.MajorService;
+import com.zerobase.babdeusilbun.service.SchoolService;
+import com.zerobase.babdeusilbun.util.TestUserUtility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(MajorController.class)
+public class MajorControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MajorService majorService;
+
+    @DisplayName("학과 검색 테스트")
+    @WithMockUser
+    @Test
+    void searchMajor() throws Exception {
+        //given
+        MajorDto.Information info = new MajorDto.Information(1L, "가짜 학과");
+        Page<MajorDto.Information> expectedPage = new PageImpl<>(List.of(info));
+
+        //when
+        when(majorService.searchMajor(anyString(), anyInt(), anyInt()))
+                .thenReturn(expectedPage);
+
+        //then
+        mockMvc.perform(get("/api/majors")
+                        .param("majorName", "")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].name").value("가짜 학과"))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.pageable").exists());
+    }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/service/MajorServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/MajorServiceTest.java
@@ -1,0 +1,45 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.dto.MajorDto;
+import com.zerobase.babdeusilbun.repository.MajorRepository;
+import com.zerobase.babdeusilbun.service.impl.MajorServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MajorServiceTest {
+    @Mock
+    private MajorRepository majorRepository;
+
+    @InjectMocks
+    private MajorServiceImpl majorService;
+
+    @DisplayName("학과 검색 서비스 테스트")
+    @Test
+    void searchMajor() {
+        //given
+        int page = 0;
+        int size = 10;
+        String search = "가짜";
+        String[] keywords = search.split(" +");
+        Page<MajorDto.Information> expectedPage = new PageImpl<>(Collections.emptyList());
+
+        //when
+        when(majorRepository.searchMajorNameByKeywords(keywords, page, size)).thenReturn(expectedPage);
+        Page<MajorDto.Information> result = majorService.searchMajor(search, page, size);
+
+        //then
+        assertEquals(expectedPage, result);
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 현재 로그인한 사용자의 정보를 조회하는 기능이 구현되지 않았습니다.

**TO-BE**
- 현재 로그인한 사용자의 정보를 조회하는 API("/api/users/my-page")를 구현하였습니다. 
- 해당 API에서 사용될 서비스와 쿼리를 구현하였습니다.
- 사용자가 등록한 은행 정보를 DB에 값을 구분하기 쉬운 형태로 저장하기 위해서 BankAccount 클래스에 있는 변수 bank에 @Enumerated[(EnumType.STRING) 어노테이션을 추가하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 