### PR TITLE
refactor: 와일드카드 제거, dto 변환 위치 변경, QueryDsl 사용 축소

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -3,6 +3,7 @@ package com.zerobase.babdeusilbun.inquiry.controller;
 import static org.springframework.http.HttpStatus.*;
 
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto;
+import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.DetailResponse;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryImageDto;
 import com.zerobase.babdeusilbun.inquiry.service.InquiryService;
@@ -41,14 +42,19 @@ public class InquiryController {
       @RequestParam String statusFilter, Pageable pageable
   ) {
 
-    return ResponseEntity.ok(inquiryService.getInquiryList(statusFilter, pageable));
+    return ResponseEntity.ok(
+        inquiryService.getInquiryList(statusFilter, pageable)
+            .map(InquiryDto.ListResponse::fromEntity)
+    );
   }
 
   // 문의 게시물 상세 조회
   @GetMapping("/{inquiryId}")
   public ResponseEntity<InquiryDto.DetailResponse> getInquiryInfo(@PathVariable Long inquiryId) {
 
-    return ResponseEntity.ok(inquiryService.getInquiryInfo(inquiryId));
+    return ResponseEntity.ok(
+        DetailResponse.fromEntity(inquiryService.getInquiryInfo(inquiryId))
+    );
   }
 
   // 문의 게시글 작성
@@ -66,9 +72,13 @@ public class InquiryController {
 
   // 문의 이미지 전체 조회
   @GetMapping("/{inquiryId}/images")
-  public ResponseEntity<Page<InquiryImageDto>> getInquiryImages(@PathVariable Long inquiryId, Pageable pageable) {
+  public ResponseEntity<Page<InquiryImageDto>> getInquiryImages
+  (@PathVariable Long inquiryId, Pageable pageable) {
 
-    return ResponseEntity.ok(inquiryService.getInquiryImageList(inquiryId, pageable));
+    return ResponseEntity.ok(
+        inquiryService.getInquiryImageList(inquiryId, pageable)
+            .map(InquiryImageDto::fromEntity)
+    );
   }
 
   // 문의 이미지 순서 변경

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/controller/InquiryController.java
@@ -37,7 +37,7 @@ public class InquiryController {
 
   // 문의 게시물 목록 조회
   @GetMapping
-  public ResponseEntity<?> getInquiryList(
+  public ResponseEntity<Page<ListResponse>> getInquiryList(
       @RequestParam String statusFilter, Pageable pageable
   ) {
 
@@ -46,14 +46,14 @@ public class InquiryController {
 
   // 문의 게시물 상세 조회
   @GetMapping("/{inquiryId}")
-  public ResponseEntity<?> getInquiryInfo(@PathVariable Long inquiryId) {
+  public ResponseEntity<InquiryDto.DetailResponse> getInquiryInfo(@PathVariable Long inquiryId) {
 
     return ResponseEntity.ok(inquiryService.getInquiryInfo(inquiryId));
   }
 
   // 문의 게시글 작성
   @PostMapping
-  public ResponseEntity<?> createInquiry(
+  public ResponseEntity<Void> createInquiry(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @Validated @RequestPart("request") InquiryDto.Request request,
       @RequestPart(value = "files", required = false) List<MultipartFile> images
@@ -66,14 +66,14 @@ public class InquiryController {
 
   // 문의 이미지 전체 조회
   @GetMapping("/{inquiryId}/images")
-  public ResponseEntity<?> getInquiryImages(@PathVariable Long inquiryId, Pageable pageable) {
+  public ResponseEntity<Page<InquiryImageDto>> getInquiryImages(@PathVariable Long inquiryId, Pageable pageable) {
 
     return ResponseEntity.ok(inquiryService.getInquiryImageList(inquiryId, pageable));
   }
 
   // 문의 이미지 순서 변경
   @PatchMapping("/{inquiryId}/images/{imageId}")
-  public ResponseEntity<?> updateInquiryImageSequence(
+  public ResponseEntity<Void> updateInquiryImageSequence(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @PathVariable Long inquiryId, @PathVariable Long imageId,
       @RequestParam Integer sequence
@@ -87,7 +87,7 @@ public class InquiryController {
 
   // 문의 이미지 삭제
   @DeleteMapping("/{inquiryId}/images/{imageId}")
-  public ResponseEntity<?> deleteInquiryImage(
+  public ResponseEntity<Void> deleteInquiryImage(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @PathVariable Long inquiryId, @PathVariable Long imageId
   ) {

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/InquiryService.java
@@ -1,5 +1,7 @@
 package com.zerobase.babdeusilbun.inquiry.service;
 
+import com.zerobase.babdeusilbun.domain.Inquiry;
+import com.zerobase.babdeusilbun.domain.InquiryImage;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.ListResponse;
 import com.zerobase.babdeusilbun.inquiry.dto.InquiryDto.Request;
@@ -12,13 +14,13 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface InquiryService {
 
-  Page<ListResponse> getInquiryList(String statusFilter, Pageable pageable);
+  Page<Inquiry> getInquiryList(String statusFilter, Pageable pageable);
 
-  InquiryDto.DetailResponse getInquiryInfo(Long inquiryId);
+  Inquiry getInquiryInfo(Long inquiryId);
 
   void createInquiry(CustomUserDetails userDetails, Request request, List<MultipartFile> images);
 
-  Page<InquiryImageDto> getInquiryImageList(Long inquiryId, Pageable pageable);
+  Page<InquiryImage> getInquiryImageList(Long inquiryId, Pageable pageable);
 
   void updateImageSequence(CustomUserDetails userDetails, Long inquiryId, Long imageId, Integer updatedSequence);
 

--- a/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/inquiry/service/impl/InquiryServiceImpl.java
@@ -42,14 +42,14 @@ public class InquiryServiceImpl implements InquiryService {
 
 
   @Override
-  public Page<ListResponse> getInquiryList(String statusFilter, Pageable pageable) {
+  public Page<Inquiry> getInquiryList(String statusFilter, Pageable pageable) {
     return inquiryRepository
-        .findInquiryList(statusFilter, pageable).map(ListResponse::fromEntity);
+        .findInquiryList(statusFilter, pageable);
   }
 
   @Override
-  public DetailResponse getInquiryInfo(Long inquiryId) {
-    return DetailResponse.fromEntity(findInquiryById(inquiryId));
+  public Inquiry getInquiryInfo(Long inquiryId) {
+    return findInquiryById(inquiryId);
   }
 
   @Override
@@ -73,10 +73,9 @@ public class InquiryServiceImpl implements InquiryService {
   }
 
   @Override
-  public Page<InquiryImageDto> getInquiryImageList(Long inquiryId, Pageable pageable) {
+  public Page<InquiryImage> getInquiryImageList(Long inquiryId, Pageable pageable) {
 
-    return inquiryImageRepository.findAllByInquiryOrderBySequence(findInquiryById(inquiryId), pageable)
-        .map(InquiryImageDto::fromEntity);
+    return inquiryImageRepository.findAllByInquiryOrderBySequence(findInquiryById(inquiryId), pageable);
   }
 
   @Override

--- a/src/main/java/com/zerobase/babdeusilbun/meeting/controller/MeetingController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/meeting/controller/MeetingController.java
@@ -46,7 +46,8 @@ public class MeetingController {
   ) {
 
     return ResponseEntity.ok(
-        meetingService.getAllMeetingList(schoolId, sortCriteria, searchMenu, categoryFilter, pageable)
+        meetingService.getAllMeetingDtoList(schoolId, sortCriteria, searchMenu, categoryFilter,
+            pageable)
     );
   }
 
@@ -56,7 +57,7 @@ public class MeetingController {
   public ResponseEntity<MeetingDto> getMeetingInfo(@PathVariable Long meetingId) {
 
     return ResponseEntity.ok(
-        meetingService.getMeetingInfo(meetingId)
+        meetingService.getMeetingInfoDto(meetingId)
     );
   }
 
@@ -103,7 +104,9 @@ public class MeetingController {
       @PathVariable Long meetingId
   ) {
 
-    return ResponseEntity.ok(meetingService.getMeetingLeaderInfo(meetingId));
+    return ResponseEntity.ok(
+        MeetingUserDto.fromEntity(meetingService.getMeetingLeaderInfo(meetingId))
+    );
   }
 
   // 모임원 조회 api
@@ -112,14 +115,19 @@ public class MeetingController {
       @PathVariable Long meetingId, Pageable pageable
   ) {
 
-    return ResponseEntity.ok(meetingService.getMeetingParticipants(meetingId, pageable));
+    return ResponseEntity.ok(
+        meetingService.getMeetingParticipants(meetingId, pageable).map(MeetingUserDto::fromEntity)
+    );
   }
 
   // 모임 현재 참가자 수 조회 /api/users/meetings/{meetingId}/headcount
   @GetMapping("/users/meetings/{meetingId}/headcount")
   public ResponseEntity<MeetingHeadCountDto> getMeetingHeadCount(@PathVariable Long meetingId) {
 
-    return ResponseEntity.ok(meetingService.getMeetingHeadCount(meetingId));
+    return ResponseEntity.ok(
+        MeetingHeadCountDto.builder()
+            .headcount(meetingService.getMeetingHeadCount(meetingId))
+            .build());
   }
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/meeting/controller/MeetingController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/meeting/controller/MeetingController.java
@@ -2,12 +2,15 @@ package com.zerobase.babdeusilbun.meeting.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
+import com.zerobase.babdeusilbun.dto.MeetingDto;
+import com.zerobase.babdeusilbun.meeting.dto.MeetingHeadCountDto;
 import com.zerobase.babdeusilbun.meeting.dto.MeetingUserDto;
 import com.zerobase.babdeusilbun.meeting.dto.MeetingRequest;
 import com.zerobase.babdeusilbun.meeting.service.MeetingService;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -34,7 +37,7 @@ public class MeetingController {
   // 정렬: 결제 마감 시간 순, 배송시간 짧은 순, 배달비 적은 순, 최소주문금액 낮은 순
   @PreAuthorize("hasRole('USER')")
   @GetMapping("/users/meetings")
-  public ResponseEntity<?> getAllMeetingList(
+  public ResponseEntity<Page<MeetingDto>> getAllMeetingList(
       @RequestParam Long schoolId,
       @RequestParam String sortCriteria,
       @RequestParam String searchMenu,
@@ -50,7 +53,7 @@ public class MeetingController {
 
   // 모임 정보 조회 api
   @GetMapping("/users/meetings/{meetingId}")
-  public ResponseEntity<?> getMeetingInfo(@PathVariable Long meetingId) {
+  public ResponseEntity<MeetingDto> getMeetingInfo(@PathVariable Long meetingId) {
 
     return ResponseEntity.ok(
         meetingService.getMeetingInfo(meetingId)
@@ -60,7 +63,7 @@ public class MeetingController {
   // 모임 생성 api
   @PreAuthorize("hasRole('USER')")
   @PostMapping("/users/meetings")
-  public ResponseEntity<?> createMeeting(
+  public ResponseEntity<Void> createMeeting(
       @Validated @RequestBody MeetingRequest.Create request,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
@@ -71,7 +74,7 @@ public class MeetingController {
   // 가게 주문 전 모임 정보 수정 api
   @PreAuthorize("hasRole('USER')")
   @PostMapping("/users/meetings/{meetingId}")
-  public ResponseEntity<?> updateMeetingInfo(
+  public ResponseEntity<Void> updateMeetingInfo(
       @PathVariable Long meetingId,
       @Validated @RequestBody MeetingRequest.Update request,
       @AuthenticationPrincipal CustomUserDetails userDetails
@@ -84,7 +87,7 @@ public class MeetingController {
   // 모임 탈퇴/취소 api
   @PreAuthorize("hasRole('USER')")
   @DeleteMapping("/users/meetings/{meetingId}")
-  public ResponseEntity<?> withdrawMeeting(
+  public ResponseEntity<Void> withdrawMeeting(
       @PathVariable Long meetingId,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
@@ -96,7 +99,7 @@ public class MeetingController {
 
   // 모임장 조회 api
   @GetMapping("/users/meetings/{meetingId}/owner")
-  public ResponseEntity<?> getMeetingLeaderInfo(
+  public ResponseEntity<MeetingUserDto> getMeetingLeaderInfo(
       @PathVariable Long meetingId
   ) {
 
@@ -105,7 +108,7 @@ public class MeetingController {
 
   // 모임원 조회 api
   @GetMapping("/users/meetings/{meetingId}/participant")
-  public ResponseEntity<?> getMeetingParticipantInfo(
+  public ResponseEntity<Page<MeetingUserDto>> getMeetingParticipantInfo(
       @PathVariable Long meetingId, Pageable pageable
   ) {
 
@@ -114,7 +117,7 @@ public class MeetingController {
 
   // 모임 현재 참가자 수 조회 /api/users/meetings/{meetingId}/headcount
   @GetMapping("/users/meetings/{meetingId}/headcount")
-  public ResponseEntity<?> getMeetingHeadCount(@PathVariable Long meetingId) {
+  public ResponseEntity<MeetingHeadCountDto> getMeetingHeadCount(@PathVariable Long meetingId) {
 
     return ResponseEntity.ok(meetingService.getMeetingHeadCount(meetingId));
   }

--- a/src/main/java/com/zerobase/babdeusilbun/meeting/service/MeetingService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/meeting/service/MeetingService.java
@@ -1,5 +1,7 @@
 package com.zerobase.babdeusilbun.meeting.service;
 
+import com.zerobase.babdeusilbun.domain.Meeting;
+import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.dto.MeetingDto;
 import com.zerobase.babdeusilbun.meeting.dto.MeetingHeadCountDto;
 import com.zerobase.babdeusilbun.meeting.dto.MeetingUserDto;
@@ -7,15 +9,20 @@ import com.zerobase.babdeusilbun.meeting.dto.MeetingRequest;
 import com.zerobase.babdeusilbun.meeting.dto.MeetingRequest.Update;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MeetingService {
 
-  Page<MeetingDto> getAllMeetingList(Long schoolId, String sortCriteria, String searchMenu,
-      Long categoryFilter, Pageable pageable);
+  Page<MeetingDto> getAllMeetingDtoList(Long schoolId, String sortCriteria, String searchMenu, Long categoryFilter, Pageable pageable);
 
-  MeetingDto getMeetingInfo(Long meetingId);
+  Page<Meeting> getAllMeetingList
+      (Long schoolId, String sortCriteria, String searchMenu, Long categoryFilter, Pageable pageable);
+
+  MeetingDto getMeetingInfoDto(Long meetingId);
+
+  Meeting getMeetingInfo(Long meetingId);
 
   void createMeeting(MeetingRequest.Create request, CustomUserDetails userDetails);
 
@@ -23,9 +30,9 @@ public interface MeetingService {
 
   void withdrawMeeting(Long meetingId, CustomUserDetails userDetails);
 
-  MeetingUserDto getMeetingLeaderInfo(Long meetingId);
+  User getMeetingLeaderInfo(Long meetingId);
 
-  Page<MeetingUserDto> getMeetingParticipants(Long meetingId, Pageable pageable);
+  Page<User> getMeetingParticipants(Long meetingId, Pageable pageable);
 
-  MeetingHeadCountDto getMeetingHeadCount(Long meetingId);
+  int getMeetingHeadCount(Long meetingId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/meeting/service/impl/MeetingServiceImpl.java
@@ -15,12 +15,10 @@ import com.zerobase.babdeusilbun.dto.MetAddressDto;
 import com.zerobase.babdeusilbun.dto.StoreImageDto;
 import com.zerobase.babdeusilbun.dto.MeetingDto;
 import com.zerobase.babdeusilbun.exception.CustomException;
-import com.zerobase.babdeusilbun.meeting.dto.MeetingHeadCountDto;
-import com.zerobase.babdeusilbun.meeting.dto.MeetingUserDto;
 import com.zerobase.babdeusilbun.meeting.dto.MeetingRequest.Update;
 import com.zerobase.babdeusilbun.meeting.scheduler.MeetingScheduler;
 import com.zerobase.babdeusilbun.meeting.service.MeetingService;
-import com.zerobase.babdeusilbun.repository.MeetingQueryRepository;
+import com.zerobase.babdeusilbun.repository.custom.impl.CustomMeetingRepositoryImpl;
 import com.zerobase.babdeusilbun.repository.MeetingRepository;
 import com.zerobase.babdeusilbun.repository.PurchaseRepository;
 import com.zerobase.babdeusilbun.repository.StoreImageRepository;
@@ -40,7 +38,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingServiceImpl implements MeetingService {
 
   private final MeetingRepository meetingRepository;
-  private final MeetingQueryRepository meetingQueryRepository;
   private final StoreImageRepository storeImageRepository;
   private final UserRepository userRepository;
   private final StoreRepository storeRepository;
@@ -64,7 +61,7 @@ public class MeetingServiceImpl implements MeetingService {
       (Long schoolId, String sortCriteria, String searchMenu,
       Long categoryFilter, Pageable pageable) {
 
-    return meetingQueryRepository
+    return meetingRepository
         .findFilteredMeetingList(schoolId, sortCriteria, searchMenu, categoryFilter, pageable);
   }
 
@@ -160,14 +157,14 @@ public class MeetingServiceImpl implements MeetingService {
   @Transactional(readOnly = true)
   public Page<User> getMeetingParticipants(Long meetingId, Pageable pageable) {
 
-    return meetingQueryRepository
-        .findAllParticipantFromMeeting(meetingId, pageable);
+    return userRepository
+        .findAllMeetingParticipant(meetingId, pageable);
   }
 
   @Override
   @Transactional(readOnly = true)
   public int getMeetingHeadCount(Long meetingId) {
-    return meetingQueryRepository.getParticipantCount(meetingId).intValue();
+    return userRepository.countMeetingParticipant(meetingId).intValue();
   }
 
 
@@ -212,7 +209,6 @@ public class MeetingServiceImpl implements MeetingService {
         .status(meeting.getStatus())
         .description(meeting.getDescription())
         .build();
-
   }
 
   private Meeting createMeetingFromRequest(Create request, User leader) {

--- a/src/main/java/com/zerobase/babdeusilbun/meeting/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/meeting/service/impl/MeetingServiceImpl.java
@@ -47,21 +47,37 @@ public class MeetingServiceImpl implements MeetingService {
   private final PurchaseRepository purchaseRepository;
   private final MeetingScheduler meetingScheduler;
 
+
   @Override
   @Transactional(readOnly = true)
-  public Page<MeetingDto> getAllMeetingList
-      (Long schoolId, String sortCriteria, String searchMenu,
+  public Page<MeetingDto> getAllMeetingDtoList(
+      Long schoolId, String sortCriteria, String searchMenu,
       Long categoryFilter, Pageable pageable) {
 
-    return meetingQueryRepository
-        .findFilteredMeetingList(schoolId, sortCriteria, searchMenu, categoryFilter, pageable)
+    return getAllMeetingList(schoolId, sortCriteria, searchMenu, categoryFilter, pageable)
         .map(this::mapToMeetingDto);
   }
 
   @Override
   @Transactional(readOnly = true)
-  public MeetingDto getMeetingInfo(Long meetingId) {
-    return mapToMeetingDto(findMeetingById(meetingId));
+  public Page<Meeting> getAllMeetingList
+      (Long schoolId, String sortCriteria, String searchMenu,
+      Long categoryFilter, Pageable pageable) {
+
+    return meetingQueryRepository
+        .findFilteredMeetingList(schoolId, sortCriteria, searchMenu, categoryFilter, pageable);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public MeetingDto getMeetingInfoDto(Long meetingId) {
+    return mapToMeetingDto(getMeetingInfo(meetingId));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Meeting getMeetingInfo(Long meetingId) {
+    return findMeetingById(meetingId);
   }
 
   @Override
@@ -135,25 +151,23 @@ public class MeetingServiceImpl implements MeetingService {
 
   @Override
   @Transactional(readOnly = true)
-  public MeetingUserDto getMeetingLeaderInfo(Long meetingId) {
+  public User getMeetingLeaderInfo(Long meetingId) {
 
-    return MeetingUserDto.fromEntity(findMeetingById(meetingId).getLeader());
+    return findMeetingById(meetingId).getLeader();
   }
 
   @Override
   @Transactional(readOnly = true)
-  public Page<MeetingUserDto> getMeetingParticipants(Long meetingId, Pageable pageable) {
+  public Page<User> getMeetingParticipants(Long meetingId, Pageable pageable) {
 
     return meetingQueryRepository
-        .findAllParticipantFromMeeting(meetingId, pageable)
-        .map(MeetingUserDto::fromEntity);
+        .findAllParticipantFromMeeting(meetingId, pageable);
   }
 
   @Override
   @Transactional(readOnly = true)
-  public MeetingHeadCountDto getMeetingHeadCount(Long meetingId) {
-    return MeetingHeadCountDto.builder()
-        .headcount(meetingQueryRepository.getParticipantCount(meetingId).intValue()).build();
+  public int getMeetingHeadCount(Long meetingId) {
+    return meetingQueryRepository.getParticipantCount(meetingId).intValue();
   }
 
 

--- a/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
@@ -2,12 +2,13 @@ package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Meeting;
 import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.repository.custom.CustomMeetingRepository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+public interface MeetingRepository extends JpaRepository<Meeting, Long>, CustomMeetingRepository {
 
   @Query("select m from meeting m "
       + "where m.leader = :leader "

--- a/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.zerobase.babdeusilbun.repository;
 import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.dto.UserDto;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -25,4 +27,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
           "where user.email = :email and school.id = user.school.id and major.id = user.major.id \n" +
           "group by user.id \n")
   Optional<UserDto.MyPage> findMyPageByEmail(String email);
+
+  @Query("select count(u.id) "
+        + "from User u "
+        + "join purchase p on p.user = u "
+        + "where p.meeting.id = :meetingId")
+  Long countMeetingParticipant(Long meetingId);
+
+  @Query("select u "
+      + "from User u "
+      + "join purchase p on p.user = u "
+      + "where p.meeting.id = :meetingId")
+  Page<User> findAllMeetingParticipant(Long meetingId, Pageable pageable);
+
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomMeetingRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomMeetingRepository.java
@@ -1,0 +1,16 @@
+package com.zerobase.babdeusilbun.repository.custom;
+
+import com.zerobase.babdeusilbun.domain.Meeting;
+import com.zerobase.babdeusilbun.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomMeetingRepository {
+
+  Page<Meeting> findFilteredMeetingList
+      (Long schoolId, String sortParameter, String searchMenu, Long categoryFilter, Pageable pageable);
+
+//  Page<User> findAllParticipantFromMeeting(Long meetingId, Pageable pageable);
+
+//  Long getParticipantCount(Long meetingId);
+}

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomMeetingRepositoryImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomMeetingRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.zerobase.babdeusilbun.repository;
+package com.zerobase.babdeusilbun.repository.custom.impl;
 
 import static com.zerobase.babdeusilbun.domain.QMeeting.meeting;
 import static com.zerobase.babdeusilbun.domain.QPurchase.purchase;
@@ -13,6 +13,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zerobase.babdeusilbun.domain.Meeting;
 import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.meeting.enums.MeetingSortCriteria;
+import com.zerobase.babdeusilbun.repository.custom.CustomMeetingRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ import org.springframework.util.StringUtils;
 
 @Repository
 @RequiredArgsConstructor
-public class MeetingQueryRepository {
+public class CustomMeetingRepositoryImpl implements CustomMeetingRepository {
 
   private final JPAQueryFactory queryFactory;
 
@@ -35,9 +36,7 @@ public class MeetingQueryRepository {
         .join(meeting.store, store)
         .fetchJoin()
         .join(storeSchool).on(storeSchool.store.eq(store))
-        .fetchJoin()
         .join(storeCategory).on(storeCategory.store.eq(store))
-        .fetchJoin()
         .where(where(schoolId, searchMenu, categoryFilter))
         .orderBy(getOrderSpecifier(sortParameter))
         .offset(pageable.getOffset())
@@ -47,27 +46,36 @@ public class MeetingQueryRepository {
     return new PageImpl<>(meetingList, pageable, meetingList.size());
   }
 
-  public Page<User> findAllParticipantFromMeeting(Long meetingId, Pageable pageable) {
+//  @Override
+//  public Page<User> findAllParticipantFromMeeting(Long meetingId, Pageable pageable) {
+//
+//    List<User> participantList = queryFactory.selectFrom(user)
+//        .join(purchase).on(purchase.user.eq(user))
+//        .where(purchase.meeting.id.eq(meetingId))
+//        .offset(pageable.getOffset())
+//        .limit(pageable.getPageSize())
+//        .fetch();
+//
+////    Long participantCount = getParticipantCount(meetingId);
+//
+//    Long participantCount = queryFactory.select(user.count()).from(user)
+//        .join(purchase).on(purchase.user.eq(user))
+//        .where(purchase.meeting.id.eq(meetingId))
+//        .offset(pageable.getOffset())
+//        .limit(pageable.getPageSize())
+//        .fetchOne();
+//
+//    return new PageImpl<>(participantList, pageable, participantCount);
+//  }
 
-    List<User> participantList = queryFactory.selectFrom(user)
-        .join(purchase).on(purchase.user.eq(user))
-        .where(purchase.meeting.id.eq(meetingId))
-        .offset(pageable.getOffset())
-        .limit(pageable.getPageSize())
-        .fetch();
-
-    Long participantCount = getParticipantCount(meetingId);
-
-    return new PageImpl<>(participantList, pageable, participantCount);
-  }
-
-  public Long getParticipantCount(Long meetingId) {
-    return queryFactory.select(user.count())
-        .from(user)
-        .innerJoin(purchase).on(purchase.user.eq(user))
-        .where(purchase.meeting.id.eq(meetingId))
-        .fetchOne();
-  }
+//  @Override
+//  public Long getParticipantCount(Long meetingId) {
+//    return queryFactory.select(user.count())
+//        .from(user)
+//        .innerJoin(purchase).on(purchase.user.eq(user))
+//        .where(purchase.meeting.id.eq(meetingId))
+//        .fetchOne();
+//  }
 
   private BooleanExpression[] where(Long schoolId, String searchMenu, Long categoryFilter) {
     List<BooleanExpression> list = new ArrayList<>();

--- a/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.zerobase.babdeusilbun.security.controller;
 
-import static com.zerobase.babdeusilbun.security.constants.SecurityConstantsUtil.*;
+import static com.zerobase.babdeusilbun.security.constants.SecurityConstants.*;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -50,7 +50,7 @@ public class AuthController {
    * 사용자 이메일 중복확인
    */
   @PostMapping("/users/email-duplicated")
-  public ResponseEntity<?> checkEmailForUser(@Validated @RequestBody EmailCheckDto.Request request) {
+  public ResponseEntity<EmailCheckDto.Response> checkEmailForUser(@Validated @RequestBody EmailCheckDto.Request request) {
 
     return ResponseEntity.ok(
         EmailCheckDto.Response.of(signService.isUserEmailIsUnique(request.getEmail()))
@@ -61,7 +61,7 @@ public class AuthController {
    * 사업자 이메일 중복확인
    */
   @PostMapping("/businesses/email-duplicated")
-  public ResponseEntity<?> checkEmailForBusiness(@Validated @RequestBody EmailCheckDto.Request request) {
+  public ResponseEntity<EmailCheckDto.Response> checkEmailForBusiness(@Validated @RequestBody EmailCheckDto.Request request) {
 
     return ResponseEntity.ok(
             EmailCheckDto.Response.of(signService.isEntrepreneurEmailIsUnique(request.getEmail()))
@@ -72,7 +72,7 @@ public class AuthController {
    * 사용자 회원가입
    */
   @PostMapping("/users/signup")
-  public ResponseEntity<?> userSignup(@Validated @RequestBody SignRequest.UserSignUp request) {
+  public ResponseEntity<Void> userSignup(@Validated @RequestBody SignRequest.UserSignUp request) {
 
     signService.userSignUp(request);
 
@@ -83,7 +83,7 @@ public class AuthController {
    * 사업자 회원가입
    */
   @PostMapping("/businesses/signup")
-  public ResponseEntity<?> businessSignup(
+  public ResponseEntity<Void> businessSignup(
       @Validated @RequestBody SignRequest.BusinessSignUp request) {
 
     signService.entrepreneurSignUp(request);
@@ -95,7 +95,7 @@ public class AuthController {
    * 사용자 로그인
    */
   @PostMapping("/users/signin")
-  public ResponseEntity<?> userSignin(
+  public ResponseEntity<SignResponse> userSignin(
       @Validated @RequestBody SignRequest.SignIn request,
       HttpServletResponse servletResponse
   ) {
@@ -107,14 +107,12 @@ public class AuthController {
    * 사업자 로그인
    */
   @PostMapping("/businesses/signin")
-  public ResponseEntity<?> businessSignin(
+  public ResponseEntity<SignResponse> businessSignin(
       @Validated @RequestBody SignRequest.SignIn request,
       HttpServletResponse servletResponse
   ) {
 
-    SignResponse response = authApplication.entrepreneurSignin(request, servletResponse);
-
-    return ResponseEntity.ok(response);
+    return ResponseEntity.ok(authApplication.businessSignin(request, servletResponse));
   }
 
   /**
@@ -122,7 +120,7 @@ public class AuthController {
    */
   @PreAuthorize("hasAnyRole('USER', 'ENTREPRENEUR')")
   @PostMapping("/logout")
-  public ResponseEntity<?> logout(
+  public ResponseEntity<Void> logout(
       @RequestHeader(AUTHORIZATION_HEADER_NAME) String authorizationHeader,
       HttpServletResponse servletResponse
   ) {
@@ -139,7 +137,7 @@ public class AuthController {
    */
   @PreAuthorize("hasAnyRole('USER')")
   @PostMapping("/users/withdrawal")
-  public ResponseEntity<?> userWithdrawal(
+  public ResponseEntity<Void> userWithdrawal(
       @RequestHeader(AUTHORIZATION_HEADER_NAME) String authorizationHeader,
       @Validated @RequestBody WithdrawalRequest request,
       HttpServletResponse servletResponse
@@ -157,7 +155,7 @@ public class AuthController {
    */
   @PreAuthorize("hasAnyRole('ENTREPRENEUR')")
   @PostMapping("/businesses/withdrawal")
-  public ResponseEntity<?> entrepreneurWithdrawal(
+  public ResponseEntity<Void> entrepreneurWithdrawal(
       @RequestHeader(AUTHORIZATION_HEADER_NAME) String authorizationHeader,
       @Validated @RequestBody WithdrawalRequest request,
       HttpServletResponse servletResponse
@@ -174,11 +172,13 @@ public class AuthController {
    * 토큰 재발급
    */
   @PostMapping("/refresh-token")
-  public ResponseEntity<?> refreshToken(
+  public ResponseEntity<SignResponse> refreshToken(
+      @RequestHeader(AUTHORIZATION_HEADER_NAME) String authorizationHeader,
       HttpServletRequest servletRequest, HttpServletResponse servletResponse
   ) {
 
-    SignResponse response = authApplication.reGenerateToken(servletRequest, servletResponse);
+    String jwtToken = jwtValidationService.verifyJwtFromHeader(authorizationHeader);
+    SignResponse response = authApplication.reGenerateToken(jwtToken, servletRequest, servletResponse);
 
     return ResponseEntity.status(CREATED).body(response);
   }

--- a/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.zerobase.babdeusilbun.security.controller;
 
-import static com.zerobase.babdeusilbun.security.constants.SecurityConstants.*;
+import static com.zerobase.babdeusilbun.security.constants.SecurityConstantsUtil.AUTHORIZATION_HEADER_NAME;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -112,7 +112,7 @@ public class AuthController {
       HttpServletResponse servletResponse
   ) {
 
-    return ResponseEntity.ok(authApplication.businessSignin(request, servletResponse));
+    return ResponseEntity.ok(authApplication.entrepreneurSignin(request, servletResponse));
   }
 
   /**
@@ -178,7 +178,7 @@ public class AuthController {
   ) {
 
     String jwtToken = jwtValidationService.verifyJwtFromHeader(authorizationHeader);
-    SignResponse response = authApplication.reGenerateToken(jwtToken, servletRequest, servletResponse);
+    SignResponse response = authApplication.reGenerateToken(servletRequest, servletResponse);
 
     return ResponseEntity.status(CREATED).body(response);
   }

--- a/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/inquiry/service/InquiryServiceTest.java
@@ -71,8 +71,8 @@ class InquiryServiceTest {
     when(inquiryRepository.findInquiryList(anyString(), any())).thenReturn(list);
 
     // when
-    Page<ListResponse> inquiryList = inquiryService.getInquiryList("", pageable);
-    List<ListResponse> content = inquiryList.getContent();
+    Page<Inquiry> inquiryList = inquiryService.getInquiryList("", pageable);
+    List<Inquiry> content = inquiryList.getContent();
 
     // then
     assertThat(inquiryList.getTotalPages()).isEqualTo(1);
@@ -96,10 +96,10 @@ class InquiryServiceTest {
     when(inquiryRepository.findById(anyLong())).thenReturn(Optional.of(pending));
 
     // when
-    DetailResponse inquiryInfo = inquiryService.getInquiryInfo(1L);
+    Inquiry inquiryInfo = inquiryService.getInquiryInfo(1L);
 
     // then
-    assertThat(inquiryInfo.getInquiryId()).isEqualTo(1L);
+    assertThat(inquiryInfo.getId()).isEqualTo(1L);
     assertThat(inquiryInfo.getTitle()).isEqualTo(pending.getTitle());
     assertThat(inquiryInfo.getAnswer()).isEqualTo(pending.getAnswer());
     assertThat(inquiryInfo.getContent()).isEqualTo(pending.getContent());
@@ -153,8 +153,8 @@ class InquiryServiceTest {
         page);
 
     // when
-    Page<InquiryImageDto> inquiryImageList = inquiryService.getInquiryImageList(1L, pageable);
-    List<InquiryImageDto> content = inquiryImageList.getContent();
+    Page<InquiryImage> inquiryImageList = inquiryService.getInquiryImageList(1L, pageable);
+    List<InquiryImage> content = inquiryImageList.getContent();
 
     // then
     verify(inquiryRepository, times(1)).findById(1L);

--- a/src/test/java/com/zerobase/babdeusilbun/meeting/service/MeetingServiceApiTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/meeting/service/MeetingServiceApiTest.java
@@ -57,20 +57,20 @@ class MeetingServiceApiTest {
     String searchMenu = "";
     Long categoryFilter = null;
 
-    Page<MeetingDto> pageable =
+    Page<Meeting> pageable =
         meetingService.getAllMeetingList(1L, "deadline", searchMenu, categoryFilter, pageRequest);
 
-    List<MeetingDto> content = pageable.getContent();
+    List<Meeting> content = pageable.getContent();
 
     assertThat(pageable.getSize()).isEqualTo(4);
     assertThat(pageable.getTotalElements()).isEqualTo(3);
     assertThat(pageable.getTotalPages()).isEqualTo(1);
     assertThat(content.size()).isEqualTo(3);
 
-    assertThat(content.getFirst().getPaymentAvailableAt()).isEqualTo(
+    assertThat(content.getFirst().getPaymentAvailableDt()).isEqualTo(
         LocalDateTime.of(2024, Month.AUGUST, 24, 12, 0)
     );
-    assertThat(content.getLast().getPaymentAvailableAt()).isEqualTo(
+    assertThat(content.getLast().getPaymentAvailableDt()).isEqualTo(
         LocalDateTime.of(2024, Month.AUGUST, 24, 12, 20)
     );
   }
@@ -84,11 +84,11 @@ class MeetingServiceApiTest {
     Long categoryFilter = null;
 
 
-    Page<MeetingDto> pageable =
+    Page<Meeting> pageable =
         meetingService.getAllMeetingList(1L, "shipping-time", searchMenu, categoryFilter,
             pageRequest);
 
-    List<MeetingDto> content = pageable.getContent();
+    List<Meeting> content = pageable.getContent();
 
     assertThat(pageable.getSize()).isEqualTo(4);
     assertThat(pageable.getTotalElements()).isEqualTo(3);
@@ -112,18 +112,18 @@ class MeetingServiceApiTest {
     Long categoryFilter = null;
 
 
-    Page<MeetingDto> pageable =
+    Page<Meeting> pageable =
         meetingService.getAllMeetingList(1L, "shipping-fee", searchMenu, categoryFilter, pageRequest);
 
-    List<MeetingDto> content = pageable.getContent();
+    List<Meeting> content = pageable.getContent();
 
     assertThat(pageable.getSize()).isEqualTo(4);
     assertThat(pageable.getTotalElements()).isEqualTo(3);
     assertThat(pageable.getTotalPages()).isEqualTo(1);
     assertThat(content.size()).isEqualTo(3);
 
-    assertThat(content.getFirst().getDeliveryFee()).isEqualTo(3000);
-    assertThat(content.getLast().getDeliveryFee()).isEqualTo(4000);
+    assertThat(content.getFirst().getStore().getDeliveryPrice()).isEqualTo(3000);
+    assertThat(content.getLast().getStore().getDeliveryPrice()).isEqualTo(4000);
   }
 
   @Test
@@ -135,12 +135,12 @@ class MeetingServiceApiTest {
     Long categoryFilter = null;
 
 
-    Page<MeetingDto> pageable =
+    Page<Meeting> pageable =
         meetingService.getAllMeetingList(1L, "min-price", searchMenu, categoryFilter, pageRequest);
 
-    List<MeetingDto> content = pageable.getContent();
-    Long storeAId = content.getLast().getStoreId();
-    Long storeBId = content.getFirst().getStoreId();
+    List<Meeting> content = pageable.getContent();
+    Long storeAId = content.getLast().getStore().getId();
+    Long storeBId = content.getFirst().getStore().getId();
     Store findStoreA = storeRepository.findById(storeBId).get();
     Store findStoreB = storeRepository.findById(storeAId).get();
 
@@ -162,11 +162,11 @@ class MeetingServiceApiTest {
     Long categoryFilter = null;
 
 
-    Page<MeetingDto> pageable =
+    Page<Meeting> pageable =
         meetingService.getAllMeetingList(1L, "min-price", searchMenu, categoryFilter, pageRequest);
 
-    List<MeetingDto> content = pageable.getContent();
-    Long storeBId = content.getLast().getStoreId();
+    List<Meeting> content = pageable.getContent();
+    Long storeBId = content.getLast().getStore().getId();
     Store findStoreB = storeRepository.findById(storeBId).get();
 
     assertThat(pageable.getSize()).isEqualTo(4);

--- a/src/test/java/com/zerobase/babdeusilbun/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/meeting/service/MeetingServiceTest.java
@@ -124,7 +124,7 @@ public class MeetingServiceTest {
         .thenReturn(Collections.emptyList());
 
     // When
-    Page<MeetingDto> result = meetingService.getAllMeetingList(schoolId, sortCriteria, searchMenu,
+    Page<Meeting> result = meetingService.getAllMeetingList(schoolId, sortCriteria, searchMenu,
         categoryFilter, pageable);
 
     // Then
@@ -160,11 +160,11 @@ public class MeetingServiceTest {
         Collections.emptyList());
 
     // When
-    MeetingDto result = meetingService.getMeetingInfo(meetingId);
+    Meeting result = meetingService.getMeetingInfo(meetingId);
 
     // Then
     assertNotNull(result);
-    assertEquals(meetingId, result.getMeetingId());
+    assertEquals(meetingId, result.getId());
     verify(meetingRepository, times(1)).findById(meetingId);
   }
 

--- a/src/test/java/com/zerobase/babdeusilbun/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/meeting/service/MeetingServiceTest.java
@@ -24,20 +24,16 @@ import com.zerobase.babdeusilbun.domain.Purchase;
 import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.dto.DeliveryAddressDto;
-import com.zerobase.babdeusilbun.dto.MeetingDto;
 import com.zerobase.babdeusilbun.dto.MetAddressDto;
 import com.zerobase.babdeusilbun.enums.PurchaseStatus;
 import com.zerobase.babdeusilbun.enums.PurchaseType;
 import com.zerobase.babdeusilbun.exception.CustomException;
-import com.zerobase.babdeusilbun.exception.ErrorCode;
 import com.zerobase.babdeusilbun.meeting.dto.MeetingRequest;
 import com.zerobase.babdeusilbun.meeting.dto.MeetingRequest.Create;
 import com.zerobase.babdeusilbun.meeting.scheduler.MeetingScheduler;
-import com.zerobase.babdeusilbun.meeting.scheduler.MeetingSchedulerService;
 import com.zerobase.babdeusilbun.meeting.service.impl.MeetingServiceImpl;
-import com.zerobase.babdeusilbun.repository.MeetingQueryRepository;
+import com.zerobase.babdeusilbun.repository.custom.impl.CustomMeetingRepositoryImpl;
 import com.zerobase.babdeusilbun.repository.MeetingRepository;
-import com.zerobase.babdeusilbun.repository.PurchasePaymentRepository;
 import com.zerobase.babdeusilbun.repository.PurchaseRepository;
 import com.zerobase.babdeusilbun.repository.StoreImageRepository;
 import com.zerobase.babdeusilbun.repository.StoreRepository;
@@ -72,7 +68,7 @@ public class MeetingServiceTest {
   private MeetingRepository meetingRepository;
 
   @Mock
-  private MeetingQueryRepository meetingQueryRepository;
+  private CustomMeetingRepositoryImpl meetingQueryRepository;
 
   @Mock
   private StoreImageRepository storeImageRepository;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
컨트롤러에서 반환값으로 와일드카드를 사용해 명확하게 판단할 수 없었습니다.
서비스에서 반환할때 dto로 변환해 재활용성이 낮았습니다.
간단한 쿼리에도 QueryDsl을 사용하고 있었습니다.

**TO-BE**
와일드카드 대신 명확한 클래스를 넣었습니다.
entity의 dto로의 반환은 controller에서 진행하도록 변경하였습니다.
Data Jpa를 사용해도 되는 간단한 작업들은 QueryDsl 대신 data jpa로 변경하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [ ] API 테스트 