### PR TITLE
feat : 사용자 주소 변경 기능 구현 + ( 회원가입 시 nickname 정보를 입력받지 않도록 수정, 기존의 이메일 기반 조회 방식에서 식별번호 기반 조회 방식으로 변경)

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/UserController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/UserController.java
@@ -2,6 +2,7 @@ package com.zerobase.babdeusilbun.controller;
 
 import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
 
+import com.zerobase.babdeusilbun.domain.Address;
 import com.zerobase.babdeusilbun.dto.UserDto;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.UserService;
@@ -10,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,8 +27,8 @@ public class UserController {
    */
   @PreAuthorize("hasRole('USER')")
   @GetMapping("/my-page")
-  public ResponseEntity<?> getMyProfile() {
-    UserDto.MyPage myPage= userService.getMyPage();
+  public ResponseEntity<UserDto.MyPage> getMyProfile(@AuthenticationPrincipal CustomUserDetails user) {
+    UserDto.MyPage myPage= userService.getMyPage(user.getId());
     return ResponseEntity.ok(myPage);
   }
 
@@ -45,6 +47,18 @@ public class UserController {
         (request.getSchoolId() != null && changeRequest.getSchoolId() == null) ||
         (request.getMajorId() != null && changeRequest.getMajorId() == null) ?
         ResponseEntity.status(PARTIAL_CONTENT).build() : ResponseEntity.ok().build();
+  }
+
+  /**
+   * 내 주소 수정
+   */
+  @PreAuthorize("hasRole('USER')")
+  @PutMapping("/address")
+  public ResponseEntity<Void> updateAddress(
+          @AuthenticationPrincipal CustomUserDetails user,
+          @Validated @RequestBody UserDto.UpdateAddress updateAddress) {
+    userService.updateAddress(user.getId(), updateAddress);
+    return ResponseEntity.ok().build();
   }
 
   /**

--- a/src/main/java/com/zerobase/babdeusilbun/domain/User.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/User.java
@@ -94,4 +94,12 @@ public class User extends BaseEntity{
     if (request.getImage() != null) this.image = request.getImage();
     if (request.getPhoneNumber() != null) this.phoneNumber = request.getPhoneNumber();
   }
+
+  public void updateAddress(UserDto.UpdateAddress address) {
+    this.address = Address.builder()
+            .postal(address.getPostal())
+            .streetAddress(address.getStreetAddress())
+            .detailAddress(address.getDetailAddress())
+            .build();
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/UserDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/UserDto.java
@@ -1,10 +1,8 @@
 package com.zerobase.babdeusilbun.dto;
 
 import com.zerobase.babdeusilbun.domain.BankAccount;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
 import com.zerobase.babdeusilbun.domain.Address;
 
 import java.util.List;
@@ -20,6 +18,21 @@ public class UserDto {
     private String phoneNumber;
     private Long schoolId;
     private Long majorId;
+  }
+
+  @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class UpdateAddress {
+
+    @NotBlank(message = "postal 항목은 빈값이 올 수 없습니다.")
+    private String postal;
+
+    @NotBlank(message = "streetAddress 항목은 빈값이 올 수 없습니다.")
+    private String streetAddress;
+
+    @NotBlank(message = "detailAddress 항목은 빈값이 올 수 없습니다.")
+    private String detailAddress;
   }
 
   @Data

--- a/src/main/java/com/zerobase/babdeusilbun/repository/EvaluateRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/EvaluateRepository.java
@@ -12,23 +12,23 @@ public interface EvaluateRepository extends JpaRepository<Evaluate, Long> {
             "select evaluate.content as content, ifnull(count(evaluate.content), 0) as count \n" +
                     "from com.zerobase.babdeusilbun.domain.User as user, \n" +
                     "com.zerobase.babdeusilbun.domain.Evaluate as evaluate \n" +
-                    "where evaluate.evaluateeId = user.id and user.email = :email and " +
+                    "where evaluate.evaluateeId = user.id and user.id = :userId and " +
                     "(evaluate.content = com.zerobase.babdeusilbun.enums.EvaluateBadge.GOOD_COMMUNICATION or \n" +
                     "evaluate.content = com.zerobase.babdeusilbun.enums.EvaluateBadge.GOOD_TIMECHECK or \n" +
                     "evaluate.content = com.zerobase.babdeusilbun.enums.EvaluateBadge.GOOD_TOGETHER or \n" +
                     "evaluate.content = com.zerobase.babdeusilbun.enums.EvaluateBadge.GOOD_RESPONSE) \n" +
                     "group by content \n")
-    List<EvaluateDto.PositiveEvaluate> findPositiveEvaluatesByEmail(String email);
+    List<EvaluateDto.PositiveEvaluate> findPositiveEvaluatesByUserId(Long userId);
 
     @Query(value=
             "select evaluate.content as content, ifnull(count(evaluate.content), 0) as count \n" +
                     "from com.zerobase.babdeusilbun.domain.User as user, \n" +
                     "com.zerobase.babdeusilbun.domain.Evaluate as evaluate \n" +
-                    "where evaluate.evaluateeId = user.id and user.email = :email and " +
+                    "where evaluate.evaluateeId = user.id and user.id = :userId and " +
                     "(evaluate.content = com.zerobase.babdeusilbun.enums.EvaluateBadge.BAD_RESPONSE or \n" +
                     "evaluate.content = com.zerobase.babdeusilbun.enums.EvaluateBadge.BAD_TIMECHECK or \n" +
                     "evaluate.content = com.zerobase.babdeusilbun.enums.EvaluateBadge.BAD_TOGETHER) \n" +
                     "group by content \n")
-    List<EvaluateDto.NegativeEvaluate> findNegativeEvaluatesByEmail(String email);
+    List<EvaluateDto.NegativeEvaluate> findNegativeEvaluatesByUserId(Long userId);
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
@@ -15,18 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   Optional<User> findByIdAndDeletedAtIsNull(Long userId);
-
-  @Query(value=
-      "select user.email as email, user.name as name, user.nickname as nickname, user.phoneNumber as phoneNumber, " +
-          "user.bankAccount as bankAccount, user.point as point, user.address as address, user.image as image, user.isBanned as isBanned," +
-          " ifnull(count(purchase.id), 0) as meetingCount, school.name as school, school.campus as campus, major.name as major \n" +
-          "from com.zerobase.babdeusilbun.domain.User as user \n" +
-          "left join com.zerobase.babdeusilbun.domain.Purchase as purchase on user.id = purchase.user.id, \n" +
-          "com.zerobase.babdeusilbun.domain.School as school, \n" +
-          "com.zerobase.babdeusilbun.domain.Major as major \n" +
-          "where user.email = :email and school.id = user.school.id and major.id = user.major.id \n" +
-          "group by user.id \n")
-  Optional<UserDto.MyPage> findMyPageByEmail(String email);
   
   @Query(value=
           "select user.email as email, user.name as name, user.nickname as nickname, user.phoneNumber as phoneNumber, " +

--- a/src/main/java/com/zerobase/babdeusilbun/security/dto/SignRequest.java
+++ b/src/main/java/com/zerobase/babdeusilbun/security/dto/SignRequest.java
@@ -43,8 +43,8 @@ public class SignRequest {
     @NotBlank(message = "name 항목은 빈값이 올 수 없습니다.")
     private String name;
 
-    @NotBlank(message = "nickname 항목은 빈값이 올 수 없습니다.")
-    private String nickname;
+    // @NotBlank(message = "nickname 항목은 빈값이 올 수 없습니다.")
+    // private String nickname;
 
     @NotBlank(message = "phoneNumber 항목은 빈값이 올 수 없습니다.")
     private String phoneNumber;

--- a/src/main/java/com/zerobase/babdeusilbun/service/EvaluateService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/EvaluateService.java
@@ -3,5 +3,5 @@ package com.zerobase.babdeusilbun.service;
 import com.zerobase.babdeusilbun.dto.EvaluateDto;
 
 public interface EvaluateService {
-    EvaluateDto.MyEvaluates getEvaluates();
+    EvaluateDto.MyEvaluates getEvaluates(Long userId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/UserService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/UserService.java
@@ -1,13 +1,16 @@
 package com.zerobase.babdeusilbun.service;
 
+import com.zerobase.babdeusilbun.domain.Address;
 import com.zerobase.babdeusilbun.dto.UserDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
 
-  UserDto.MyPage getMyPage();
+  UserDto.MyPage getMyPage(Long userId);
 
   UserDto.Profile getUserProfile(Long userId);
 
   UserDto.UpdateRequest updateProfile(Long userId, MultipartFile image, UserDto.UpdateRequest request);
+
+  UserDto.UpdateAddress updateAddress(Long userId, UserDto.UpdateAddress updateAddress);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/EvaluateServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/EvaluateServiceImpl.java
@@ -4,13 +4,9 @@ import com.zerobase.babdeusilbun.dto.EvaluateDto;
 import com.zerobase.babdeusilbun.repository.EvaluateRepository;
 import com.zerobase.babdeusilbun.service.EvaluateService;
 import lombok.AllArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-
-import static com.zerobase.babdeusilbun.security.constants.SecurityConstantsUtil.getOriginalEmail;
 
 @Service
 @AllArgsConstructor
@@ -18,21 +14,10 @@ public class EvaluateServiceImpl implements EvaluateService {
 
     private final EvaluateRepository evaluateRepository;
 
-    // 현재 로그인한 사람의 이메일 정보를 가져오는 함수
-    private String getLoginUserEmail() {
-        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContextHolderStrategy()
-                .getContext()
-                .getAuthentication()
-                .getPrincipal();
-
-        return getOriginalEmail(userDetails.getUsername());
-    }
-
     @Override
-    public EvaluateDto.MyEvaluates getEvaluates() {
-        String loginUserEmail = getLoginUserEmail();
-        List<EvaluateDto.PositiveEvaluate> positiveEvaluateList = evaluateRepository.findPositiveEvaluatesByEmail(loginUserEmail);
-        List<EvaluateDto.NegativeEvaluate> negativeEvaluateList = evaluateRepository.findNegativeEvaluatesByEmail(loginUserEmail);
+    public EvaluateDto.MyEvaluates getEvaluates(Long userId) {
+        List<EvaluateDto.PositiveEvaluate> positiveEvaluateList = evaluateRepository.findPositiveEvaluatesByUserId(userId);
+        List<EvaluateDto.NegativeEvaluate> negativeEvaluateList = evaluateRepository.findNegativeEvaluatesByUserId(userId);
 
         EvaluateDto.MyEvaluates evaluates = EvaluateDto.MyEvaluates.builder().positiveEvaluate(positiveEvaluateList).negativeEvaluate(negativeEvaluateList).build();
         return evaluates;

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/EvaluateServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/EvaluateServiceImpl.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.zerobase.babdeusilbun.security.constants.SecurityConstantsUtil.getOriginalEmail;
+
 @Service
 @AllArgsConstructor
 public class EvaluateServiceImpl implements EvaluateService {
@@ -23,8 +25,7 @@ public class EvaluateServiceImpl implements EvaluateService {
                 .getAuthentication()
                 .getPrincipal();
 
-        int splitIndex = userDetails.getUsername().indexOf("_", 5);
-        return userDetails.getUsername().substring(splitIndex+1);
+        return getOriginalEmail(userDetails.getUsername());
     }
 
     @Override

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.zerobase.babdeusilbun.service.impl;
 
 import static com.zerobase.babdeusilbun.exception.ErrorCode.USER_NOT_FOUND;
+import static com.zerobase.babdeusilbun.security.constants.SecurityConstantsUtil.getOriginalEmail;
 import static com.zerobase.babdeusilbun.util.ImageUtility.USER_IMAGE_FOLDER;
 
 import com.zerobase.babdeusilbun.component.ImageComponent;
@@ -43,8 +44,7 @@ public class UserServiceImpl implements UserService {
             .getAuthentication()
             .getPrincipal();
 
-    int splitIndex = userDetails.getUsername().indexOf("_", 5);
-    return userDetails.getUsername().substring(splitIndex+1);
+    return getOriginalEmail(userDetails.getUsername());
   }
 
   // 내 정보 조회

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
@@ -1,7 +1,6 @@
 package com.zerobase.babdeusilbun.service.impl;
 
 import static com.zerobase.babdeusilbun.exception.ErrorCode.USER_NOT_FOUND;
-import static com.zerobase.babdeusilbun.security.constants.SecurityConstantsUtil.getOriginalEmail;
 import static com.zerobase.babdeusilbun.util.ImageUtility.USER_IMAGE_FOLDER;
 
 import com.zerobase.babdeusilbun.component.ImageComponent;
@@ -9,7 +8,9 @@ import com.zerobase.babdeusilbun.domain.Major;
 import com.zerobase.babdeusilbun.domain.School;
 import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.dto.EvaluateDto;
-import com.zerobase.babdeusilbun.dto.UserDto;
+import com.zerobase.babdeusilbun.dto.UserDto.MyPage;
+import com.zerobase.babdeusilbun.dto.UserDto.Profile;
+import com.zerobase.babdeusilbun.dto.UserDto.UpdateAddress;
 import com.zerobase.babdeusilbun.dto.UserDto.UpdateRequest;
 import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.repository.EvaluateRepository;
@@ -20,8 +21,6 @@ import com.zerobase.babdeusilbun.service.UserService;
 import io.micrometer.common.util.StringUtils;
 import java.util.List;
 import lombok.AllArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,32 +36,22 @@ public class UserServiceImpl implements UserService {
   private final ImageComponent imageComponent;
   private final PasswordEncoder passwordEncoder;
 
-  // 현재 로그인한 사람의 이메일 정보를 가져오는 함수
-  private String getLoginUserEmail() {
-    UserDetails userDetails = (UserDetails) SecurityContextHolder.getContextHolderStrategy()
-            .getContext()
-            .getAuthentication()
-            .getPrincipal();
-
-    return getOriginalEmail(userDetails.getUsername());
-  }
-
   // 내 정보 조회
   @Override
-  public UserDto.MyPage getMyPage() {
-    return userRepository.findMyPageByEmail(getLoginUserEmail())
+  public MyPage getMyPage(Long userId) {
+    return userRepository.findMyPageByUserId(userId)
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
   }
 
   // userId를 기반으로 프로필 정보 조회
   @Override
-  public UserDto.Profile getUserProfile(Long userId) {
-    UserDto.MyPage userPage = userRepository.findMyPageByUserId(userId)
+  public Profile getUserProfile(Long userId) {
+    MyPage userPage = userRepository.findMyPageByUserId(userId)
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-    List<EvaluateDto.PositiveEvaluate> positiveEvaluate = evaluateRepository.findPositiveEvaluatesByEmail(userPage.getEmail());
+    List<EvaluateDto.PositiveEvaluate> positiveEvaluate = evaluateRepository.findPositiveEvaluatesByUserId(userId);
 
-    UserDto.Profile userProfile = UserDto.Profile.builder()
+    Profile userProfile = Profile.builder()
             .nickname(userPage.getNickname())
             .image(userPage.getImage())
             .major(userPage.getMajor())
@@ -94,6 +83,16 @@ public class UserServiceImpl implements UserService {
 
     user.update(request);
     return request;
+  }
+
+  // 사용자의 주소 정보를 업데이트
+  @Override
+  @Transactional
+  public UpdateAddress updateAddress(Long userId, UpdateAddress updateAddress) {
+    User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    user.updateAddress(updateAddress);
+    return updateAddress;
   }
 
   private void updateSchool(User user, UpdateRequest request) {

--- a/src/test/java/com/zerobase/babdeusilbun/controller/UserControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/UserControllerTest.java
@@ -4,9 +4,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.babdeusilbun.dto.UserDto.UpdateAddress;
 import com.zerobase.babdeusilbun.dto.UserDto.UpdateRequest;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.UserService;
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -100,5 +103,26 @@ public class UserControllerTest {
               return httpRequest;
             }))
         .andExpect(status().isPartialContent());
+  }
+
+  @DisplayName("내 주소 수정 컨트롤러 테스트")
+  @Test
+  void updateAddressSuccess() throws Exception {
+    // given
+    UpdateAddress input = new UpdateAddress("postal", "streetAddress", "detailAddress");
+    MockMultipartFile request = new MockMultipartFile(
+            "request", "request", "application/json",
+            objectMapper.writeValueAsString(input).getBytes());
+
+    // when
+    when(userService.updateAddress(eq(testUser.getId()), eq(input))).thenReturn(input);
+
+    // then
+    mockMvc.perform(
+            put("/api/users/address")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(input)))
+            .andExpect(status().isOk());
   }
 }

--- a/src/test/java/com/zerobase/babdeusilbun/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/UserServiceTest.java
@@ -1,17 +1,21 @@
 package com.zerobase.babdeusilbun.service;
 
+import static com.zerobase.babdeusilbun.security.type.Role.ROLE_USER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.zerobase.babdeusilbun.component.ImageComponent;
+import com.zerobase.babdeusilbun.domain.Address;
 import com.zerobase.babdeusilbun.domain.Major;
 import com.zerobase.babdeusilbun.domain.School;
 import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.UserDto.UpdateAddress;
 import com.zerobase.babdeusilbun.dto.UserDto.UpdateRequest;
 import com.zerobase.babdeusilbun.repository.MajorRepository;
 import com.zerobase.babdeusilbun.repository.SchoolRepository;
 import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.impl.UserServiceImpl;
 import com.zerobase.babdeusilbun.util.TestUserUtility;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +24,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -68,5 +74,23 @@ public class UserServiceTest {
     assertEquals(request.getNickname(), user.getNickname());
     assertEquals("encodedPassword", user.getPassword());
     assertEquals(originImage, user.getImage());
+  }
+
+  @DisplayName("내 주소 수정 테스트")
+  @Test
+  void updateAddress() {
+    // given
+    User user = TestUserUtility.getUser();
+    UpdateAddress updateAddress = new UpdateAddress("변경주소1", "변경주소2", "변경주소3");
+
+    when(userRepository.findByIdAndDeletedAtIsNull(eq(user.getId()))).thenReturn(java.util.Optional.of(user));
+
+    // when
+    UpdateAddress address = userService.updateAddress(user.getId(), updateAddress);
+
+    // then
+    assertEquals(address.getPostal(), user.getAddress().getPostal());
+    assertEquals(address.getStreetAddress(), user.getAddress().getStreetAddress());
+    assertEquals(address.getDetailAddress(), user.getAddress().getDetailAddress());
   }
 }

--- a/src/test/java/com/zerobase/babdeusilbun/util/TestUserUtility.java
+++ b/src/test/java/com/zerobase/babdeusilbun/util/TestUserUtility.java
@@ -1,5 +1,6 @@
 package com.zerobase.babdeusilbun.util;
 
+import com.zerobase.babdeusilbun.domain.Address;
 import com.zerobase.babdeusilbun.domain.School;
 import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
@@ -15,6 +16,7 @@ public class TestUserUtility {
       .email("test@test.com")
       .password("password")
       .school(school)
+      .address(Address.builder().postal("가짜주소1").streetAddress("가짜주소2").detailAddress("가짜주소3").build())
       .build();
 
   public static CustomUserDetails createTestUser() {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 현재 로그인중인 사용자의 주소 정보를 변경하는 메서드를 구현해야 했습니다.

- 사용자 회원가입 시 닉네임은 자동생성되기 때문에 닉네임 정보를 가져올 필요가 없었습니다.

- 동일한 서비스 클래스 안에서 하나는 식별번호를 기반으로, 다른하나는 이메일을 기반으로 사용자 관련 정보를 가져오고 있었기에 둘 중 한가지 방식으로 통일을 하는 것이 좋다는 생각이 들었습니다.

**TO-BE**
- 변경할 주소 정보를 저장할 DTO를 생성하였습니다.

- 현재 로그인 중인 사용자의 주소 정보를 변경하는 메서드들을 구현하였습니다.

- 주소 정보 변경이 잘 수행되는지 확인할 수 있는 테스트코드들을 구현하였습니다.

- 사용자 회원가입 시 닉네임 정보를 가져오지 않도록 해당 DTO의 닉네임 변수에 주석처리를 하였습니다. 주석처리를 한 이유는  나중에 닉네임 생성 방식이 변경되었을 때 빠르게 해당 기능을 다시 만들기 위함입니다.

-  확인 결과 식별번호를 기반으로 조회하는 방식으로 먼저 구현이 되어 있었고, 해당 방식은 테스트 코드 작성시 더 편리한 방식인 것으로 확인되었습니다. 따라서, 기존에 이메일을 기반으로 정보를 가져오는 기능들을 식별번호를 기반으로 정보를 가져오는 방식으로 변경하였습니다.


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 