### PR TITLE
feature: 배달가능 캠퍼스 등록, 제외 기능 구현, refactor: 상점 생성 시 response로 상점id 반환하도록 변경 test: 추가된 기능, 변경된 기능에 맞게 수정

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/domain/StoreSchool.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/StoreSchool.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,10 +20,18 @@ import lombok.NoArgsConstructor;
 /**
  * 매장 - 배달 가능 학교 매핑
  */
-@Entity(name = "store_school") @Getter
+@Entity @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
 @Builder
+@Table(
+    name = "store_school",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            columnNames = {"store_id", "school_id"}
+        )
+    }
+)
 public class StoreSchool extends BaseEntity{
 
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/zerobase/babdeusilbun/dto/SchoolDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/SchoolDto.java
@@ -3,8 +3,13 @@ package com.zerobase.babdeusilbun.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import com.zerobase.babdeusilbun.domain.School;
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 public class SchoolDto {
   @Data
@@ -48,5 +53,13 @@ public class SchoolDto {
       this.name = name.replaceAll("(\\s|\\()[^\\s]+((캠퍼스)|\\))$", "");
       this.campus = campus;
     }
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  public static class IdsRequest {
+    private Set<Long> schoolIds = new HashSet<>();
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
@@ -101,4 +101,10 @@ public class StoreDto {
           .build();
     }
   }
+
+  @Data
+  @Builder
+  public static class IdResponse {
+    private Long storeId;
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreImageRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreImageRepository.java
@@ -4,9 +4,12 @@ import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.StoreImage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {
 
   List<StoreImage> findAllByStoreOrderBySequenceAsc(Store store);
+  int countByStore(Store store);
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreSchoolRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreSchoolRepository.java
@@ -1,7 +1,18 @@
 package com.zerobase.babdeusilbun.repository;
 
+import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.StoreSchool;
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StoreSchoolRepository extends JpaRepository<StoreSchool, Long> {
+  @Query("SELECT ss.school.id FROM StoreSchool ss WHERE ss.store = :store")
+  List<Long> findSchoolIdsByStore(@Param("store") Store store);
+
+  int deleteByStoreAndSchool_IdIn(Store store, Set<Long> schoolIds);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
@@ -2,14 +2,19 @@ package com.zerobase.babdeusilbun.service;
 
 import com.zerobase.babdeusilbun.dto.CategoryDto;
 import com.zerobase.babdeusilbun.dto.CategoryDto.Information;
+import com.zerobase.babdeusilbun.dto.SchoolDto;
+import com.zerobase.babdeusilbun.dto.StoreDto;
 import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface StoreService {
-  int createStore(Long entrepreneurId, List<MultipartFile> images, CreateRequest request);
+  StoreDto.IdResponse createStore(Long entrepreneurId, CreateRequest request);
+  int uploadImageToStore(Long entrepreneurId, List<MultipartFile> images, Long storeId);
   Page<Information> getAllCategories(int page, int size);
   int enrollToCategory(Long entrepreneurId, Long storeId, CategoryDto.IdsRequest request);
   int deleteOnCategory(Long entrepreneurId, Long storeId, CategoryDto.IdsRequest request);
+  int enrollSchoolsToStore(Long entrepreneurId, Long storeId, SchoolDto.IdsRequest request);
+  int deleteSchoolsOnStore(Long entrepreneurId, Long storeId, SchoolDto.IdsRequest request);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
@@ -9,12 +9,16 @@ import static com.zerobase.babdeusilbun.util.ImageUtility.STORE_IMAGE_FOLDER;
 import com.zerobase.babdeusilbun.component.ImageComponent;
 import com.zerobase.babdeusilbun.domain.Category;
 import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.domain.School;
 import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.StoreCategory;
 import com.zerobase.babdeusilbun.domain.StoreImage;
+import com.zerobase.babdeusilbun.domain.StoreSchool;
 import com.zerobase.babdeusilbun.dto.CategoryDto.IdsRequest;
 import com.zerobase.babdeusilbun.dto.CategoryDto.Information;
+import com.zerobase.babdeusilbun.dto.SchoolDto;
 import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
+import com.zerobase.babdeusilbun.dto.StoreDto.IdResponse;
 import com.zerobase.babdeusilbun.dto.StoreDto.ImageUrl;
 import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.repository.CategoryRepository;
@@ -23,6 +27,7 @@ import com.zerobase.babdeusilbun.repository.SchoolRepository;
 import com.zerobase.babdeusilbun.repository.StoreCategoryRepository;
 import com.zerobase.babdeusilbun.repository.StoreImageRepository;
 import com.zerobase.babdeusilbun.repository.StoreRepository;
+import com.zerobase.babdeusilbun.repository.StoreSchoolRepository;
 import com.zerobase.babdeusilbun.service.StoreService;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,13 +48,14 @@ public class StoreServiceImpl implements StoreService {
   private final StoreRepository storeRepository;
   private final StoreImageRepository imageRepository;
   private final SchoolRepository schoolRepository;
+  private final StoreSchoolRepository storeSchoolRepository;
   private final CategoryRepository categoryRepository;
   private final StoreCategoryRepository storeCategoryRepository;
   private final ImageComponent imageComponent;
 
   @Override
   @Transactional
-  public int createStore(Long entrepreneurId, List<MultipartFile> images, CreateRequest request) {
+  public IdResponse createStore(Long entrepreneurId, CreateRequest request) {
     Entrepreneur entrepreneur = entrepreneurRepository
         .findByIdAndDeletedAtIsNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
 
@@ -59,21 +65,36 @@ public class StoreServiceImpl implements StoreService {
       throw new CustomException(ALREADY_EXIST_STORE);
     }
 
-    Store store = request.toEntity(entrepreneur);
-    storeRepository.save(store);
+    Store store = storeRepository.save(request.toEntity(entrepreneur));
+
+    return IdResponse.builder().storeId(store.getId()).build();
+  }
+
+  @Override
+  @Transactional
+  public int uploadImageToStore(Long entrepreneurId, List<MultipartFile> images, Long storeId) {
+    Entrepreneur entrepreneur = entrepreneurRepository
+        .findByIdAndDeletedAtIsNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+
+    Store store = storeRepository
+        .findByIdAndDeletedAtIsNull(storeId).orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
+
+    if (store.getEntrepreneur() != entrepreneur) {
+      throw new CustomException(NO_AUTH_ON_STORE);
+    }
 
     List<StoreImage> uploadImageList = new ArrayList<>();
-    AtomicInteger sequence = new AtomicInteger();
+    AtomicInteger sequence = new AtomicInteger(imageRepository.countByStore(store));
 
     imageComponent.uploadImageList(images, STORE_IMAGE_FOLDER).forEach(url ->
-      uploadImageList.add(
-          ImageUrl.builder()
-              .url(url)
-              .isRepresentative(sequence.get() == 0)
-              .sequence(sequence.getAndIncrement())
-              .build()
-              .toEntity(store)
-      )
+        uploadImageList.add(
+            ImageUrl.builder()
+                .url(url)
+                .isRepresentative(sequence.get() == 0)
+                .sequence(sequence.getAndIncrement())
+                .build()
+                .toEntity(store)
+        )
     );
 
     if (!uploadImageList.isEmpty()) {
@@ -145,5 +166,63 @@ public class StoreServiceImpl implements StoreService {
     }
 
     return storeCategoryRepository.deleteByStoreAndCategory_IdIn(store, request.getCategoryIds());
+  }
+
+  @Override
+  @Transactional
+  public int enrollSchoolsToStore(Long entrepreneurId, Long storeId, SchoolDto.IdsRequest request) {
+    Entrepreneur entrepreneur = entrepreneurRepository
+        .findByIdAndDeletedAtIsNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+
+    Store store = storeRepository
+        .findByIdAndDeletedAtIsNull(storeId).orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
+
+    if (store.getEntrepreneur() != entrepreneur) {
+      throw new CustomException(NO_AUTH_ON_STORE);
+    }
+
+    List<Long> curSchoolIds = storeSchoolRepository.findSchoolIdsByStore(store);
+    AtomicInteger count = new AtomicInteger();
+
+    request.getSchoolIds().forEach(id -> {
+      if (curSchoolIds.contains(id)) {
+        log.info("this school is already enrolled on this store."
+            + " schoolId -> {}, storeId -> {}", id, store.getId());
+
+        return;
+      }
+      Optional<School> school = schoolRepository.findById(id);
+
+      //카테고리로 조회된 게 없는 경우
+      if (school.isEmpty()) {
+        log.error("failed to enroll school on store cause there's no school found by id."
+            + " schoolId -> {}, storeId -> {} ", id, store.getId());
+      } else {
+        storeSchoolRepository.save(StoreSchool.builder()
+            .store(store)
+            .school(school.get())
+            .build());
+
+        count.getAndIncrement();
+      }
+    });
+
+    return count.get();
+  }
+
+  @Override
+  @Transactional
+  public int deleteSchoolsOnStore(Long entrepreneurId, Long storeId, SchoolDto.IdsRequest request) {
+    Entrepreneur entrepreneur = entrepreneurRepository
+        .findByIdAndDeletedAtIsNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+
+    Store store = storeRepository
+        .findByIdAndDeletedAtIsNull(storeId).orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
+
+    if (store.getEntrepreneur() != entrepreneur) {
+      throw new CustomException(NO_AUTH_ON_STORE);
+    }
+
+    return storeSchoolRepository.deleteByStoreAndSchool_IdIn(store, request.getSchoolIds());
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 상점을 생성했을 때 반환하는 값은 Void로, 생성한 상점의 id를 알 수 없었습니다.
- 상점에 카테고리를 등록하고, 학교를 등록하는 과정에서 id를 url을 입력해야 해 프론트가 값을 전달할 수 있어야 합니다.
- 상점에서 배달 가능한 캠퍼스를 등록, 제거하는 기능이 필요했습니다.
- 기존 상점과 학교를 잇는 매핑 테이블에 복합키 설정이 되어있지 않았습니다.

**TO-BE**
- 상점을 생성했을 때 id를 반환할 수 있도록 수정하였습니다.
- 기존 create와 imageupload가 서비스 기능에 함께 있었으나, image 업로드 부분을 분리하였습니다.
- 상점에서 배달 가능한 캠퍼스를 등록, 제거하는 기능을 생성했습니다.
  - 입력값이 반영되지 않았을 땐 NoContent, 입력값이 부분 반영되었을 땐 PartialSuccess, 모두 반영되었을 땐 Ok 상태코드가 반환되도록 구현하였습니다.
- 상점과 학교를 잇는 매핑 테이블에 복합키를 설정하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 수정된 상점 생성 코드에 맞춰 컨트롤러, 서비스 테스트코드 수정
  - 학교에 배달가능학교 등록, 제외하는 컨트롤러와 서비스 테스트코드 각 사례에 맞춰 구현
- [x] API 테스트 