### PR TITLE
feat : 상점의 메뉴 추가 기능 구현 및 테스트 코드 작성 ( + ErrorCode 추가 및 수정 ) 

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/MenuController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/MenuController.java
@@ -1,0 +1,45 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.zerobase.babdeusilbun.dto.MenuDto;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MenuController {
+
+    private final MenuService menuService;
+
+    /**
+     * 메뉴 등록
+     */
+    @PreAuthorize("hasRole('ENTREPRENEUR')")
+    @PostMapping(value = "/businesses/stores/{storeId}/menus",
+            consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<Void> createMenu(
+            @AuthenticationPrincipal
+    CustomUserDetails entrepreneur,
+            @PathVariable("storeId") Long storeId,
+            @RequestPart(value = "file", required = false) MultipartFile image,
+            @RequestPart(value = "request") MenuDto.CreateRequest request) {
+
+        MenuDto.CreateRequest result = menuService.createMenu(entrepreneur.getId(), storeId, image, request);
+
+        return (image != null && result.getImage() == null) ?
+                ResponseEntity.status(PARTIAL_CONTENT).build() : ResponseEntity.status(CREATED).build();
+    }
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/domain/Menu.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/Menu.java
@@ -12,11 +12,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 
 /**
  * 메뉴
@@ -25,6 +22,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
 @Builder
+@EqualsAndHashCode
 @Table(name = "menu",
     // 가게에서 같은 메뉴(메뉴 이름과 가격이 동일)는 등록하지 못함
     uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "name", "price"})

--- a/src/main/java/com/zerobase/babdeusilbun/dto/MenuDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/MenuDto.java
@@ -1,0 +1,38 @@
+package com.zerobase.babdeusilbun.dto;
+
+import com.zerobase.babdeusilbun.domain.Menu;
+import com.zerobase.babdeusilbun.domain.Store;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.*;
+
+public class MenuDto {
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
+    public static class CreateRequest {
+        @NotBlank(message = "name 항목은 빈값이 올 수 없습니다.")
+        private String name;
+
+        @NotBlank(message = "description 항목은 빈값이 올 수 없습니다.")
+        private String description;
+
+        private String image;
+
+        @PositiveOrZero(message = "price 항목은 0이상만 올 수 있습니다.")
+        private long price;
+
+        public Menu toEntity(Store store) {
+            return Menu.builder()
+                    .store(store)
+                    .name(name)
+                    .image(image)
+                    .description(description)
+                    .price(price)
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -68,7 +68,10 @@ public enum ErrorCode {
   // 상점 관련
   STORE_NOT_FOUND(NOT_FOUND, "couldn't find store"),
   ALREADY_EXIST_STORE(CONFLICT, "already have store which user want to enroll."),
-  NO_AUTH_ON_STORE(FORBIDDEN, "no auth to modify or delete this storage"),
+  NO_AUTH_ON_STORE(FORBIDDEN, "no auth to use or modify or delete this storage"),
+
+  // 메뉴 관련
+  ALREADY_EXIST_MENU(CONFLICT, "already have menu which user want to enroll."),
 
   //이메일 인증 관련
   CANNOT_SEND_MAIL_EXCEEDS_MAX_COUNT(BAD_REQUEST,

--- a/src/main/java/com/zerobase/babdeusilbun/repository/MenuRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MenuRepository.java
@@ -1,7 +1,9 @@
 package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Menu;
+import com.zerobase.babdeusilbun.domain.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+    boolean existsByStoreAndNameAndPriceAndDeletedAtIsNull(Store store, String name, long price);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
@@ -4,6 +4,8 @@ import com.zerobase.babdeusilbun.domain.Address;
 import com.zerobase.babdeusilbun.domain.Entrepreneur;
 import com.zerobase.babdeusilbun.domain.Store;
 import java.util.Optional;
+import java.util.OptionalInt;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
@@ -11,4 +13,6 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
       Entrepreneur entrepreneur, String name, Address address);
 
   Optional<Store> findByIdAndDeletedAtIsNull(Long storeId);
+
+  Optional<Store> findByIdAndEntrepreneur(Long storeId, Entrepreneur entrepreneur);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/MenuService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/MenuService.java
@@ -1,0 +1,8 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.dto.MenuDto;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface MenuService {
+    MenuDto.CreateRequest createMenu(Long entrepreneurId, Long storeId, MultipartFile image, MenuDto.CreateRequest request);
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/MenuServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/MenuServiceImpl.java
@@ -1,0 +1,69 @@
+package com.zerobase.babdeusilbun.service.impl;
+
+import com.zerobase.babdeusilbun.component.ImageComponent;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.domain.Menu;
+import com.zerobase.babdeusilbun.domain.Store;
+import com.zerobase.babdeusilbun.dto.MenuDto;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.repository.EntrepreneurRepository;
+import com.zerobase.babdeusilbun.repository.MenuRepository;
+import com.zerobase.babdeusilbun.repository.StoreRepository;
+import com.zerobase.babdeusilbun.service.MenuService;
+import io.micrometer.common.util.StringUtils;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
+import static com.zerobase.babdeusilbun.util.ImageUtility.MENU_IMAGE_FOLDER;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class MenuServiceImpl implements MenuService {
+    private final EntrepreneurRepository entrepreneurRepository;
+    private final StoreRepository storeRepository;
+    private final MenuRepository menuRepository;
+
+    private final ImageComponent imageComponent;
+
+    // 메뉴 등록
+    @Override
+    public MenuDto.CreateRequest createMenu(Long entrepreneurId, Long storeId, MultipartFile image, MenuDto.CreateRequest request) {
+        Entrepreneur entrepreneur = entrepreneurRepository
+                .findByIdAndDeletedAtIsNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+
+        Store store = storeRepository.findByIdAndEntrepreneur(storeId, entrepreneur)
+                .orElseThrow(() -> new CustomException(NO_AUTH_ON_STORE));
+
+        if (menuRepository.existsByStoreAndNameAndPriceAndDeletedAtIsNull(store, request.getName(), request.getPrice())) {
+            throw new CustomException(ALREADY_EXIST_MENU);
+        }
+
+        if(image != null) {
+            createImage(image, request);
+        } else {
+            request.setImage(null);
+        }
+
+        Menu menu = menuRepository.save(request.toEntity(store));
+
+        return new MenuDto.CreateRequest(menu.getName(), menu.getDescription(), menu.getImage(), menu.getPrice());
+    }
+
+    // 이미지 업로드
+    public void createImage(MultipartFile image, MenuDto.CreateRequest request) {
+        List<String> uploadUrlList = imageComponent.uploadImageList(List.of(image), MENU_IMAGE_FOLDER);
+
+        if (uploadUrlList.isEmpty()) {
+            request.setImage(null);
+            return;
+        }
+
+        request.setImage(uploadUrlList.getFirst());
+    }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/controller/MenuControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/MenuControllerTest.java
@@ -1,0 +1,131 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.babdeusilbun.dto.MenuDto;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.MenuService;
+import com.zerobase.babdeusilbun.util.TestEntrepreneurUtility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MenuController.class)
+public class MenuControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MenuService menuService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private CustomUserDetails testEntrepreneur;
+
+    private final MenuDto.CreateRequest createRequest = MenuDto.CreateRequest.builder().
+            name("가짜메뉴").description("가짜설명").image("url").price(200L).build();
+
+    private final MenuDto.CreateRequest responseRequestNotImage = MenuDto.CreateRequest.builder().
+            name("가짜메뉴").description("가짜설명").image(null).price(200L).build();
+
+    @BeforeEach
+    void setUp() {
+        //로그인 정보 세팅
+        testEntrepreneur = TestEntrepreneurUtility.createTestEntrepreneur();
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(testEntrepreneur, null, testEntrepreneur.getAuthorities())
+        );
+    }
+
+    @DisplayName("메뉴 등록 컨트롤러 테스트(이미지 업로드 X, 완전 성공)")
+    @Test
+    void createMenu() throws Exception {
+        //given
+        MockMultipartFile request = new MockMultipartFile(
+                "request", "request", "application/json",
+                objectMapper.writeValueAsString(createRequest).getBytes());
+
+        // when
+        when(menuService.createMenu(eq(testEntrepreneur.getId()), eq(1L), eq(null), eq(createRequest)))
+                .thenReturn(responseRequestNotImage);
+
+        // then
+        mockMvc.perform(multipart(HttpMethod.POST, "/api/businesses/stores/1/menus")
+                .file(request)
+                .with(csrf())
+                .with(httpRequest -> {
+                    httpRequest.setMethod("POST");
+                    return httpRequest;
+                }))
+                .andExpect(status().isCreated());
+    }
+
+    @DisplayName("메뉴 등록 컨트롤러 테스트(이미지 업로드 + 완전 성공)")
+    @Test
+    void createMenuWithImageUploadSuccess() throws Exception {
+        //given
+        MockMultipartFile request = new MockMultipartFile(
+                "request", "request", "application/json",
+                objectMapper.writeValueAsString(createRequest).getBytes());
+
+        MockMultipartFile image = new MockMultipartFile(
+                "file", "image.png", "image/png", "1".getBytes());
+
+        // when
+        when(menuService.createMenu(eq(testEntrepreneur.getId()), eq(1L), eq(image), eq(createRequest)))
+                .thenReturn(createRequest);
+
+        // then
+        mockMvc.perform(multipart(HttpMethod.POST, "/api/businesses/stores/1/menus")
+                        .file(image)
+                        .file(request)
+                        .with(csrf())
+                        .with(httpRequest -> {
+                            httpRequest.setMethod("POST");
+                            return httpRequest;
+                        }))
+                .andExpect(status().isCreated());
+    }
+
+    @DisplayName("메뉴 등록 컨트롤러 테스트(이미지 업로드 실패로 인한 부분 성공)")
+    @Test
+    void createMenuWithImageUploadFail() throws Exception {
+        //given
+        MockMultipartFile request = new MockMultipartFile(
+                "request", "request", "application/json",
+                objectMapper.writeValueAsString(createRequest).getBytes());
+
+        MockMultipartFile image = new MockMultipartFile(
+                "file", "image.png", "image/png", "1".getBytes());
+
+        // when
+        when(menuService.createMenu(eq(testEntrepreneur.getId()), eq(1L), eq(image), eq(createRequest)))
+                .thenReturn(responseRequestNotImage);
+
+        // then
+        mockMvc.perform(multipart(HttpMethod.POST, "/api/businesses/stores/1/menus")
+                        .file(image)
+                        .file(request)
+                        .with(csrf())
+                        .with(httpRequest -> {
+                            httpRequest.setMethod("POST");
+                            return httpRequest;
+                        }))
+                .andExpect(status().isPartialContent());
+    }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/service/MenuServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/MenuServiceTest.java
@@ -1,0 +1,180 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.component.ImageComponent;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.domain.Menu;
+import com.zerobase.babdeusilbun.domain.Store;
+import com.zerobase.babdeusilbun.dto.MenuDto;
+import com.zerobase.babdeusilbun.repository.EntrepreneurRepository;
+import com.zerobase.babdeusilbun.repository.MenuRepository;
+import com.zerobase.babdeusilbun.repository.StoreRepository;
+import com.zerobase.babdeusilbun.service.impl.MenuServiceImpl;
+import com.zerobase.babdeusilbun.util.TestEntrepreneurUtility;
+import com.zerobase.babdeusilbun.util.TestStoreUtility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+
+import static com.zerobase.babdeusilbun.util.ImageUtility.MENU_IMAGE_FOLDER;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MenuServiceTest {
+
+    @Mock
+    private EntrepreneurRepository entrepreneurRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @Mock
+    private ImageComponent imageComponent;
+
+    @InjectMocks
+    private MenuServiceImpl menuService;
+
+    private final MenuDto.CreateRequest createRequest = MenuDto.CreateRequest.builder().
+            name("가짜메뉴").description("가짜설명").image("url").price(200L).build();
+
+    private final MultipartFile testMultipartFile = new MultipartFile() {
+        @Override
+        public String getName() {
+            return "파일1";
+        }
+
+        @Override
+        public String getOriginalFilename() {
+            return "파일2";
+        }
+
+        @Override
+        public String getContentType() {
+            return "파일3";
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public long getSize() {
+            return 5;
+        }
+
+        @Override
+        public byte[] getBytes() throws IOException {
+            return new byte[0];
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return null;
+        }
+
+        @Override
+        public void transferTo(File dest) throws IOException, IllegalStateException {
+
+        }
+    };
+
+    @DisplayName("메뉴 생성 테스트 (이미지 업로드 X)")
+    @Test
+    void createMenu() {
+        //given
+        Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
+        Store store = TestStoreUtility.getStore();
+        createRequest.setImage(null);
+        Menu expected = createRequest.toEntity(store);
+
+        when(entrepreneurRepository.findByIdAndDeletedAtIsNull(eq(entrepreneur.getId())))
+                .thenReturn(Optional.of(entrepreneur));
+        when(storeRepository.findByIdAndEntrepreneur(eq(store.getId()), eq(entrepreneur)))
+                .thenReturn(Optional.of(store));
+        when(menuRepository.save(eq(createRequest.toEntity(store)))).thenReturn(expected);
+
+        //when
+        MenuDto.CreateRequest result = menuService.createMenu(entrepreneur.getId(), store.getId(), testMultipartFile, createRequest);
+
+        //then
+        assertEquals(createRequest.getName(), result.getName());
+        assertEquals(createRequest.getDescription(), result.getDescription());
+        assertEquals(createRequest.getImage(), result.getImage());
+        assertEquals(createRequest.getPrice(), result.getPrice());
+    }
+
+    @DisplayName("메뉴 생성 테스트 (이미지 업로드 성공)")
+    @Test
+    void createMenuCompleteWithImageUploadSuccess() {
+        //given
+        Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
+        Store store = TestStoreUtility.getStore();
+        Menu expected = createRequest.toEntity(store);
+
+        when(entrepreneurRepository.findByIdAndDeletedAtIsNull(eq(entrepreneur.getId())))
+                .thenReturn(Optional.of(entrepreneur));
+        when(storeRepository.findByIdAndEntrepreneur(eq(store.getId()), eq(entrepreneur)))
+                .thenReturn(Optional.of(store));
+        when(imageComponent.uploadImageList(eq(List.of(testMultipartFile)), eq(MENU_IMAGE_FOLDER)))
+                .thenReturn(List.of("url"));
+        when(menuRepository.save(eq(createRequest.toEntity(store)))).thenReturn(expected);
+
+        //when
+       MenuDto.CreateRequest result = menuService.createMenu(entrepreneur.getId(), store.getId(), testMultipartFile, createRequest);
+
+       //then
+       assertEquals(createRequest.getName(), result.getName());
+       assertEquals(createRequest.getDescription(), result.getDescription());
+       assertEquals(createRequest.getImage(), result.getImage());
+       assertEquals(createRequest.getPrice(), result.getPrice());
+
+    }
+
+    @DisplayName("메뉴 생성 테스트 (이미지 업로드 실패 시)")
+    @Test
+    void createMenuWithImageUploadFail() {
+
+        //given
+        Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
+        Store store = TestStoreUtility.getStore();
+        createRequest.setImage(null);
+        Menu expected = createRequest.toEntity(store);
+
+        //when
+        when(entrepreneurRepository.findByIdAndDeletedAtIsNull(eq(entrepreneur.getId())))
+                .thenReturn(Optional.of(entrepreneur));
+        when(storeRepository.findByIdAndEntrepreneur(eq(store.getId()), eq(entrepreneur)))
+                .thenReturn(Optional.of(store));
+        when(imageComponent.uploadImageList(eq(List.of(testMultipartFile)), eq(MENU_IMAGE_FOLDER)))
+                .thenReturn(List.of());
+        when(menuRepository.save(eq(createRequest.toEntity(store)))).thenReturn(expected);
+
+        createRequest.setImage("url");
+        MenuDto.CreateRequest result = menuService.createMenu(entrepreneur.getId(), store.getId(), testMultipartFile, createRequest);
+
+        //then
+        assertEquals(createRequest.getName(), result.getName());
+        assertEquals(createRequest.getDescription(), result.getDescription());
+        assertEquals(createRequest.getImage(), null);
+        assertEquals(result.getImage(), null);
+        assertEquals(createRequest.getPrice(), result.getPrice());
+
+    }
+}
+

--- a/src/test/java/com/zerobase/babdeusilbun/util/TestStoreUtility.java
+++ b/src/test/java/com/zerobase/babdeusilbun/util/TestStoreUtility.java
@@ -1,0 +1,27 @@
+package com.zerobase.babdeusilbun.util;
+
+import com.zerobase.babdeusilbun.domain.Address;
+import com.zerobase.babdeusilbun.domain.Store;
+
+import java.time.LocalTime;
+
+public class TestStoreUtility {
+    public static final Store store = Store.builder()
+    .id(1L)
+            .entrepreneur(TestEntrepreneurUtility.getEntrepreneur())
+            .name("가짜가게")
+            .description("가짜설명")
+            .minPurchaseAmount(2L)
+            .deliveryPrice(100L)
+            .minDeliveryTime(10)
+            .maxDeliveryTime(20)
+            .address(Address.builder().postal("가짜주소1").streetAddress("가짜주소2").detailAddress("가짜주소3").build())
+            .phoneNumber("000-111-2222")
+            .openTime(LocalTime.MIN)
+            .closeTime(LocalTime.MAX)
+            .build();
+
+    public static Store getStore() {
+        return store;
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 사업가가 자신이 등록한 상점의 메뉴를 등록하는 api를 구현해야 했습니다.

**TO-BE**
- 사업가가 상점에 메뉴를 등록하는 api를 구현하였습니다.

  - 다른 사업가의 상점에는 메뉴를 등록할 수 없습니다.
  
  - 메뉴 등록 시 이미지 등록은 선택사항이며 메뉴의 이름, 메뉴의 설명, 메뉴의 가격은 작성을 해야 하도록 구현하였습니다.
  
  - 동일한 이름,가격의 메뉴가 이미 등록되어 있는 경우에는 메뉴를 추가할 수 없도록 구현하였습니다.
  
  - 메뉴 등록시 이미지 업로드가 실패한 경우 206 status가 반환이되도록 구현하였습니다.
  
  - 메뉴 등록시 상황에 맞는 에러를 새로 추가하거나 기존의 에러 내용을 수정하였습니다.
  
  - 테스트 코드 작성을 위해 Menu 클래스에 @EqualsAndHashCode어노테이션을 추가하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트