### PR TITLE
feat : 메뉴 수정, 삭제 기능 구현 ( + 에러 코드 추가, 식별번호와 사업가 정보를 기반으로 상점을 조회시 삭제날짜도 고려하도록 수정 )

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/MenuController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/MenuController.java
@@ -1,5 +1,6 @@
 package com.zerobase.babdeusilbun.controller;
 
+import com.zerobase.babdeusilbun.domain.Menu;
 import com.zerobase.babdeusilbun.dto.MenuDto;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.MenuService;
@@ -10,8 +11,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
@@ -30,8 +29,7 @@ public class MenuController {
     @PostMapping(value = "/businesses/stores/{storeId}/menus",
             consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<Void> createMenu(
-            @AuthenticationPrincipal
-    CustomUserDetails entrepreneur,
+            @AuthenticationPrincipal CustomUserDetails entrepreneur,
             @PathVariable("storeId") Long storeId,
             @RequestPart(value = "file", required = false) MultipartFile image,
             @RequestPart(value = "request") MenuDto.CreateRequest request) {
@@ -42,4 +40,35 @@ public class MenuController {
                 ResponseEntity.status(PARTIAL_CONTENT).build() : ResponseEntity.status(CREATED).build();
     }
 
+    /**
+     * 메뉴 수정
+     */
+    @PreAuthorize("hasRole('ENTREPRENEUR')")
+    @PatchMapping(value = "/businesses/menus/{menuId}",
+            consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<Void> updateMenu(
+            @AuthenticationPrincipal CustomUserDetails entrepreneur,
+            @PathVariable("menuId") Long menuId,
+            @RequestPart(value = "file", required = false) MultipartFile image,
+            @RequestPart(value = "request") MenuDto.UpdateRequest request
+    ) {
+
+        MenuDto.UpdateRequest result = menuService.updateMenu(entrepreneur.getId(), menuId, image, request);
+
+        return (image != null && result.getImage() == null) ?
+                ResponseEntity.status(PARTIAL_CONTENT).build() : ResponseEntity.ok().build();
+    }
+
+    /**
+     * 메뉴 삭제
+     */
+    @PreAuthorize("hasRole('ENTREPRENEUR')")
+    @DeleteMapping(value = "/businesses/menus/{menuId}")
+    public ResponseEntity<Void> deleteMmenu(
+            @AuthenticationPrincipal CustomUserDetails entrepreneur,
+            @PathVariable("menuId") Long menuId) {
+
+        menuService.deleteMenu(entrepreneur.getId(), menuId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/domain/Menu.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/Menu.java
@@ -1,6 +1,7 @@
 package com.zerobase.babdeusilbun.domain;
 
 
+import com.zerobase.babdeusilbun.dto.MenuDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -23,7 +24,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
 @Builder
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper=false)
 @Table(name = "menu",
     // 가게에서 같은 메뉴(메뉴 이름과 가격이 동일)는 등록하지 못함
     uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "name", "price"})
@@ -51,4 +52,14 @@ public class Menu extends BaseEntity{
 
   private LocalDateTime deletedAt;
 
+  public void update(MenuDto.UpdateRequest request) {
+    if(request.getName() != null) this.name = request.getName();
+    if(request.getDescription() != null) this.description = request.getDescription();
+    if(request.getImage() != null) this.image = request.getImage();
+    if(request.getPrice() >= 0) this.price = request.getPrice();
+  }
+
+  public void delete() {
+    deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/MenuDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/MenuDto.java
@@ -35,4 +35,31 @@ public class MenuDto {
         }
     }
 
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
+    public static class UpdateRequest {
+        @NotBlank(message = "name 항목은 빈값이 올 수 없습니다.")
+        private String name;
+
+        @NotBlank(message = "description 항목은 빈값이 올 수 없습니다.")
+        private String description;
+
+        private String image;
+
+        @PositiveOrZero(message = "price 항목은 0이상만 올 수 있습니다.")
+        private long price;
+
+        public Menu toEntity(Store store) {
+            return Menu.builder()
+                    .store(store)
+                    .name(name)
+                    .image(image)
+                    .description(description)
+                    .price(price)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -74,7 +74,9 @@ public enum ErrorCode {
   NO_IMAGE_ON_STORE(NOT_FOUND, "cannot find image on store which request on."),
 
   // 메뉴 관련
+  MENU_NOT_FOUND(NOT_FOUND, "couldn't find menu"),
   ALREADY_EXIST_MENU(CONFLICT, "already have menu which user want to enroll."),
+  NO_AUTH_ON_MENU(FORBIDDEN, "no auth to use or modify or delete this storage"),
 
   //이메일 인증 관련
   CANNOT_SEND_MAIL_EXCEEDS_MAX_COUNT(BAD_REQUEST,

--- a/src/main/java/com/zerobase/babdeusilbun/repository/MenuRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MenuRepository.java
@@ -4,6 +4,10 @@ import com.zerobase.babdeusilbun.domain.Menu;
 import com.zerobase.babdeusilbun.domain.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+    Optional<Menu> findByIdAndDeletedAtIsNull(Long menuId);
+
     boolean existsByStoreAndNameAndPriceAndDeletedAtIsNull(Store store, String name, long price);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
@@ -4,7 +4,6 @@ import com.zerobase.babdeusilbun.domain.Address;
 import com.zerobase.babdeusilbun.domain.Entrepreneur;
 import com.zerobase.babdeusilbun.domain.Store;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -14,5 +13,5 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
   Optional<Store> findByIdAndDeletedAtIsNull(Long storeId);
 
-  Optional<Store> findByIdAndEntrepreneur(Long storeId, Entrepreneur entrepreneur);
+  Optional<Store> findByIdAndEntrepreneurAndDeletedAtIsNull(Long storeId, Entrepreneur entrepreneur);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/MenuService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/MenuService.java
@@ -1,8 +1,13 @@
 package com.zerobase.babdeusilbun.service;
 
+import com.zerobase.babdeusilbun.domain.Menu;
 import com.zerobase.babdeusilbun.dto.MenuDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface MenuService {
     MenuDto.CreateRequest createMenu(Long entrepreneurId, Long storeId, MultipartFile image, MenuDto.CreateRequest request);
+
+    MenuDto.UpdateRequest updateMenu(Long entrepreneurId, Long menuId, MultipartFile image, MenuDto.UpdateRequest request);
+
+    Menu deleteMenu(Long entrepreneurId, Long menuId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/MenuServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/MenuServiceImpl.java
@@ -14,6 +14,7 @@ import io.micrometer.common.util.StringUtils;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -37,7 +38,7 @@ public class MenuServiceImpl implements MenuService {
         Entrepreneur entrepreneur = entrepreneurRepository
                 .findByIdAndDeletedAtIsNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
 
-        Store store = storeRepository.findByIdAndEntrepreneur(storeId, entrepreneur)
+        Store store = storeRepository.findByIdAndEntrepreneurAndDeletedAtIsNull(storeId, entrepreneur)
                 .orElseThrow(() -> new CustomException(NO_AUTH_ON_STORE));
 
         if (menuRepository.existsByStoreAndNameAndPriceAndDeletedAtIsNull(store, request.getName(), request.getPrice())) {
@@ -55,13 +56,75 @@ public class MenuServiceImpl implements MenuService {
         return new MenuDto.CreateRequest(menu.getName(), menu.getDescription(), menu.getImage(), menu.getPrice());
     }
 
-    // 이미지 업로드
-    public void createImage(MultipartFile image, MenuDto.CreateRequest request) {
+    // 메뉴 수정
+    @Override
+    @Transactional
+    public MenuDto.UpdateRequest updateMenu(Long entrepreneurId, Long menuId, MultipartFile image, MenuDto.UpdateRequest request) {
+        // menuId를 기반으로 메뉴 불러오기
+        Menu menu = menuRepository.findByIdAndDeletedAtIsNull(menuId)
+                .orElseThrow(() -> new CustomException(MENU_NOT_FOUND));
+
+        // 해당 메뉴를 소지한 상점 주인이 현재 로그인한 사업자와 일치하는지 확인
+        if(entrepreneurId != menu.getStore().getEntrepreneur().getId()) {
+            throw new CustomException(NO_AUTH_ON_MENU);
+        }
+
+        // 현재 메뉴가 등록된 상점에서 수정한 메뉴랑 동일한 이름,가격을 가진 메뉴가 있는지 확인
+        if (menuRepository.existsByStoreAndNameAndPriceAndDeletedAtIsNull(menu.getStore(), request.getName(), request.getPrice())) {
+            throw new CustomException(ALREADY_EXIST_MENU);
+        }
+
+        if(image != null) {
+            updateImage(menu, image, request);
+        } else if (request.getImage() != null && request.getImage().isEmpty() && StringUtils.isNotBlank(menu.getImage())) {
+            imageComponent.deleteImageByUrl(menu.getImage());
+        }
+
+        menu.update(request);
+        return request;
+    }
+
+    // 메뉴 삭제
+    @Override
+    @Transactional
+    public Menu deleteMenu(Long entrepreneurId, Long menuId) {
+        // menuId를 기반으로 메뉴 불러오기
+        Menu menu = menuRepository.findByIdAndDeletedAtIsNull(menuId)
+                .orElseThrow(() -> new CustomException(MENU_NOT_FOUND));
+
+        // 해당 메뉴를 소지한 상점 주인이 현재 로그인한 사업자와 일치하는지 확인
+        if(entrepreneurId != menu.getStore().getEntrepreneur().getId()) {
+            throw new CustomException(NO_AUTH_ON_MENU);
+        }
+
+        menu.delete();
+
+        return menu;
+    }
+
+    // 이미지 처음 업로드
+    private void createImage(MultipartFile image, MenuDto.CreateRequest request) {
         List<String> uploadUrlList = imageComponent.uploadImageList(List.of(image), MENU_IMAGE_FOLDER);
 
         if (uploadUrlList.isEmpty()) {
             request.setImage(null);
             return;
+        }
+
+        request.setImage(uploadUrlList.getFirst());
+    }
+
+    // 이미지 수정
+    private void updateImage(Menu menu, MultipartFile image, MenuDto.UpdateRequest request) {
+        List<String> uploadUrlList = imageComponent.uploadImageList(List.of(image), MENU_IMAGE_FOLDER);
+
+        if (uploadUrlList.isEmpty()) {
+            request.setImage(null);
+            return;
+        }
+
+        if (StringUtils.isNotBlank(menu.getImage())) {
+            imageComponent.deleteImageByUrl(menu.getImage());
         }
 
         request.setImage(uploadUrlList.getFirst());

--- a/src/test/java/com/zerobase/babdeusilbun/util/TestMenuUtility.java
+++ b/src/test/java/com/zerobase/babdeusilbun/util/TestMenuUtility.java
@@ -1,0 +1,18 @@
+package com.zerobase.babdeusilbun.util;
+
+import com.zerobase.babdeusilbun.domain.Menu;
+
+public class TestMenuUtility {
+    private static final Menu menu = Menu.builder()
+            .id(1L)
+            .store(TestStoreUtility.getStore())
+            .name("가짜메뉴")
+            .image("url")
+            .description("가짜설명")
+            .price(200L)
+            .build();
+
+    public static Menu getMenu() {
+        return menu;
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 식별번호와 사업가 정보를 기반으로 상점을 조회시 삭제날짜도 고려해야 하는데 기존의 코드가 그렇지 못했습니다.

- 사업가가 자신이 등록한 상점의 메뉴를 수정하거나 삭제하는 api를 구현해야 했습니다.

**TO-BE**
  - 식별번호와 사업가 정보를 기반으로 상점을 조회시 삭제날짜가 등록되지 않은 정보만 조회하도록 기존의 코드를 수정하였습 
     니다.
  
  - 사업가가 등록했던 메뉴를 수정하거나 제거하는 api를 구현하였습니다.

  - 다른 사업가의 상점의 메뉴는 수정하거나 제거할 수 없습니다.
  
  - 메뉴 수정 시 이미지 등록은 선택사항이며 메뉴의 이름, 메뉴의 설명, 메뉴의 가격은 작성을 해야 하도록 구현하였습니다.
    만약 이미지 업로드를 하지않고 공백의 문자열을 image 값에 입력했을 경우에는 기존의 등록되어 있던 이미지를 제거하도록 
    만들었습니다.
  
  - 메뉴 수정시 이미지 업로드가 실패한 경우 206 status가 반환이되도록 구현하였습니다.
  
  - 메뉴 등록시 상황에 맞는 에러를 새로 추가하였습니다.
  
  - 원활한 테스트 수행을 위해 EqualsAndHashCode어노테이션에 (callSuper=false)을 추가하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트