### PR TITLE
feature: 주문 전 팀, 개별 장바구니 조회

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
@@ -2,7 +2,6 @@ package com.zerobase.babdeusilbun.controller;
 
 import static com.zerobase.babdeusilbun.dto.PurchaseDto.*;
 
-import com.zerobase.babdeusilbun.dto.PurchaseDto;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.PurchaseService;
 import lombok.RequiredArgsConstructor;
@@ -27,14 +26,27 @@ public class PurchaseController {
    */
   @PreAuthorize("hasRole('USER')")
   @GetMapping("/team-order")
-  public ResponseEntity<TeamPurchaseResponse> getTeamPurchaseCart(
+  public ResponseEntity<PurchaseResponse> getTeamPurchaseCart(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @PathVariable Long meetingId, Pageable pageable
   ) {
 
     return ResponseEntity.ok(
-        purchaseService.getTeamOrderCart(userDetails.getId(), meetingId, pageable));
+        purchaseService.getTeamPurchaseCart(userDetails.getId(), meetingId, pageable));
+  }
 
+  /**
+   * 주문 전 개별 주문 장바구니 조회
+   */
+  @PreAuthorize("hasRole('USER')")
+  @GetMapping("/individual-order")
+  public ResponseEntity<PurchaseResponse> getIndividualPurchaseCart(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long meetingId, Pageable pageable
+  ) {
+
+    return ResponseEntity.ok(
+        purchaseService.getIndividualPurchaseCart(userDetails.getId(), meetingId, pageable));
   }
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
@@ -1,5 +1,7 @@
 package com.zerobase.babdeusilbun.controller;
 
+import static com.zerobase.babdeusilbun.dto.PurchaseDto.*;
+
 import com.zerobase.babdeusilbun.dto.PurchaseDto;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.PurchaseService;
@@ -20,9 +22,12 @@ public class PurchaseController {
 
   private final PurchaseService purchaseService;
 
+  /**
+   * 주문 전 공동 주문 장바구니 조회
+   */
   @PreAuthorize("hasRole('USER')")
   @GetMapping("/team-order")
-  public ResponseEntity<PurchaseDto.TeamPurchaseResponse> getTeamPurchaseCart(
+  public ResponseEntity<TeamPurchaseResponse> getTeamPurchaseCart(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @PathVariable Long meetingId, Pageable pageable
   ) {

--- a/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
@@ -1,8 +1,15 @@
 package com.zerobase.babdeusilbun.controller;
 
+import com.zerobase.babdeusilbun.dto.PurchaseDto;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.PurchaseService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,5 +19,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class PurchaseController {
 
   private final PurchaseService purchaseService;
+
+  @PreAuthorize("hasRole('USER')")
+  @GetMapping("/team-order")
+  public ResponseEntity<PurchaseDto.TeamPurchaseResponse> getTeamPurchaseCart(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long meetingId, Pageable pageable
+  ) {
+
+    return ResponseEntity.ok(
+        purchaseService.getTeamOrderCart(userDetails.getId(), meetingId, pageable));
+
+  }
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
@@ -1,0 +1,16 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.zerobase.babdeusilbun.service.PurchaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users/meetings/{meetingId}")
+@RequiredArgsConstructor
+public class PurchaseController {
+
+  private final PurchaseService purchaseService;
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/dto/PurchaseDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/PurchaseDto.java
@@ -1,0 +1,40 @@
+package com.zerobase.babdeusilbun.dto;
+
+import java.util.List;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class PurchaseDto {
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @Builder
+  public static class TeamPurchaseResponse {
+
+    private Long totalFee;
+    private List<Item> items;
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Builder
+    public static class Item {
+
+      private Long purchaseId;
+      private Long menuId;
+      private String name;
+      private String image;
+      private String description;
+      private Long price;
+      private Integer quantity;
+    }
+  }
+
+
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/dto/PurchaseDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/PurchaseDto.java
@@ -1,12 +1,14 @@
 package com.zerobase.babdeusilbun.dto;
 
+import com.zerobase.babdeusilbun.domain.Menu;
+import com.zerobase.babdeusilbun.domain.TeamPurchase;
 import java.util.List;
-import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 public class PurchaseDto {
 
@@ -17,7 +19,7 @@ public class PurchaseDto {
   public static class TeamPurchaseResponse {
 
     private Long totalFee;
-    private List<Item> items;
+    private Page<Item> items;
 
     @Getter
     @AllArgsConstructor
@@ -33,6 +35,7 @@ public class PurchaseDto {
       private Long price;
       private Integer quantity;
     }
+
   }
 
 

--- a/src/main/java/com/zerobase/babdeusilbun/dto/PurchaseDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/PurchaseDto.java
@@ -1,8 +1,5 @@
 package com.zerobase.babdeusilbun.dto;
 
-import com.zerobase.babdeusilbun.domain.Menu;
-import com.zerobase.babdeusilbun.domain.TeamPurchase;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +13,7 @@ public class PurchaseDto {
   @AllArgsConstructor
   @NoArgsConstructor(access = AccessLevel.PROTECTED)
   @Builder
-  public static class TeamPurchaseResponse {
+  public static class PurchaseResponse {
 
     private Long totalFee;
     private Page<Item> items;

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
   // 모임 관련
   MEETING_NOT_FOUND(NOT_FOUND, "couldn't find meeting"),
   MEETING_STATUS_INVALID(BAD_REQUEST, "meeting status is invalid"),
+  MEETING_TYPE_INVALID(BAD_REQUEST, "meeting type is invalid"),
   MEETING_LEADER_NOT_MATCH(BAD_REQUEST, "this user is not a leader of that meeting"),
   MEETING_PARTICIPANT_NOT_MATCH(BAD_REQUEST, "this user is not a participant of that meeting"),
   MEETING_PARTICIPANT_EXIST(BAD_REQUEST, "this meeting have participants"),

--- a/src/main/java/com/zerobase/babdeusilbun/repository/IndividualPurchaseRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/IndividualPurchaseRepository.java
@@ -1,7 +1,12 @@
 package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.IndividualPurchase;
+import com.zerobase.babdeusilbun.domain.Purchase;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IndividualPurchaseRepository extends JpaRepository<IndividualPurchase, Long> {
+
+  Page<IndividualPurchase> findAllByPurchase(Purchase purchase, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/IndividualPurchaseRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/IndividualPurchaseRepository.java
@@ -4,9 +4,11 @@ import com.zerobase.babdeusilbun.domain.IndividualPurchase;
 import com.zerobase.babdeusilbun.domain.Purchase;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IndividualPurchaseRepository extends JpaRepository<IndividualPurchase, Long> {
 
+  @EntityGraph(attributePaths = {"purchase", "menu"})
   Page<IndividualPurchase> findAllByPurchase(Purchase purchase, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
@@ -4,6 +4,7 @@ import com.zerobase.babdeusilbun.domain.Meeting;
 import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.repository.custom.CustomMeetingRepository;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/zerobase/babdeusilbun/repository/PurchaseRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/PurchaseRepository.java
@@ -33,6 +33,6 @@ public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
 
   boolean existsByUser(User participant);
 
-  boolean existsByUserAndMeeting(User user, Meeting meeting);
+  boolean existsByMeetingAndUser(Meeting meeting, User user);
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/PurchaseRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/PurchaseRepository.java
@@ -7,8 +7,10 @@ import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.enums.PurchaseStatus;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.web.bind.annotation.ModelAttribute;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
 
@@ -22,6 +24,7 @@ public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
 
   List<Purchase> findAllByMeeting(Meeting meeting);
 
+  @EntityGraph(attributePaths = {"meeting", "user"})
   Optional<Purchase> findByMeetingAndUser(Meeting meeting, User user);
 
   @Query("select p from Purchase p "
@@ -29,5 +32,7 @@ public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
   List<Purchase> findProceedingByMeeting(Meeting meeting);
 
   boolean existsByUser(User participant);
+
+  boolean existsByUserAndMeeting(User user, Meeting meeting);
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/TeamPurchaseRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/TeamPurchaseRepository.java
@@ -1,8 +1,21 @@
 package com.zerobase.babdeusilbun.repository;
 
+import com.zerobase.babdeusilbun.domain.Meeting;
+import com.zerobase.babdeusilbun.domain.Purchase;
 import com.zerobase.babdeusilbun.domain.TeamPurchase;
+import com.zerobase.babdeusilbun.domain.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamPurchaseRepository extends JpaRepository<TeamPurchase, Long> {
+
+  @EntityGraph(attributePaths = {"menu", "meeting"})
+  Page<TeamPurchase> findAllByMeeting(Meeting meeting, Pageable pageable);
+
+  Long countByMeeting(Meeting meeting);
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
@@ -1,0 +1,5 @@
+package com.zerobase.babdeusilbun.service;
+
+public interface PurchaseService {
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
@@ -1,5 +1,9 @@
 package com.zerobase.babdeusilbun.service;
 
+import com.zerobase.babdeusilbun.dto.PurchaseDto.TeamPurchaseResponse;
+import org.springframework.data.domain.Pageable;
+
 public interface PurchaseService {
 
+  TeamPurchaseResponse getTeamOrderCart(Long userId, Long meetingId, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
@@ -1,11 +1,13 @@
 package com.zerobase.babdeusilbun.service;
 
-import com.zerobase.babdeusilbun.dto.PurchaseDto.TeamPurchaseResponse;
+import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface PurchaseService {
 
-  TeamPurchaseResponse getTeamOrderCart(Long userId, Long meetingId, Pageable pageable);
+  PurchaseResponse getTeamPurchaseCart(Long userId, Long meetingId, Pageable pageable);
 
+
+  PurchaseResponse getIndividualPurchaseCart(Long userId, Long meetingId, Pageable pageable);
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
@@ -6,4 +6,6 @@ import org.springframework.data.domain.Pageable;
 public interface PurchaseService {
 
   TeamPurchaseResponse getTeamOrderCart(Long userId, Long meetingId, Pageable pageable);
+
+
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
@@ -55,9 +55,7 @@ public class PurchaseServiceImpl implements PurchaseService {
     verifyDiningTogether(findMeeting);
 
     // 주문 전 모임인지 확인
-    if (findMeeting.getStatus() != GATHERING) {
-      throw new CustomException(MEETING_STATUS_INVALID);
-    }
+    verifyBeforeOrder(findMeeting);
 
     return mapToPurchaseResponse(teamPurchaseRepository.findAllByMeeting(findMeeting, pageable));
   }
@@ -102,7 +100,7 @@ public class PurchaseServiceImpl implements PurchaseService {
   }
 
   private void verifyDiningTogether(Meeting findMeeting) {
-    if (findMeeting.getPurchaseType() == PurchaseType.DINING_TOGETHER) {
+    if (findMeeting.getPurchaseType() != PurchaseType.DINING_TOGETHER) {
       throw new CustomException(MEETING_TYPE_INVALID);
     }
   }
@@ -110,6 +108,12 @@ public class PurchaseServiceImpl implements PurchaseService {
   private void verifyMeetingParticipant(User findUser, Meeting findMeeting) {
     if (!purchaseRepository.existsByUserAndMeeting(findUser, findMeeting)) {
       throw new CustomException(MEETING_PARTICIPANT_NOT_MATCH);
+    }
+  }
+
+  private void verifyBeforeOrder(Meeting findMeeting) {
+    if (findMeeting.getStatus() != GATHERING) {
+      throw new CustomException(MEETING_STATUS_INVALID);
     }
   }
 

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
@@ -1,0 +1,14 @@
+package com.zerobase.babdeusilbun.service.impl;
+
+import com.zerobase.babdeusilbun.repository.PurchaseRepository;
+import com.zerobase.babdeusilbun.service.PurchaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PurchaseServiceImpl implements PurchaseService {
+
+  private final PurchaseRepository purchaseRepository;
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
@@ -1,37 +1,125 @@
 package com.zerobase.babdeusilbun.service.impl;
 
+import static com.zerobase.babdeusilbun.dto.PurchaseDto.*;
+import static com.zerobase.babdeusilbun.enums.MeetingStatus.*;
 import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
 
+import com.zerobase.babdeusilbun.domain.Meeting;
+import com.zerobase.babdeusilbun.domain.Menu;
+import com.zerobase.babdeusilbun.domain.TeamPurchase;
 import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.PurchaseDto;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.TeamPurchaseResponse;
+import com.zerobase.babdeusilbun.dto.PurchaseDto.TeamPurchaseResponse.Item;
+import com.zerobase.babdeusilbun.enums.MeetingStatus;
+import com.zerobase.babdeusilbun.enums.PurchaseType;
 import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.exception.ErrorCode;
 import com.zerobase.babdeusilbun.repository.MeetingRepository;
 import com.zerobase.babdeusilbun.repository.PurchaseRepository;
+import com.zerobase.babdeusilbun.repository.TeamPurchaseRepository;
 import com.zerobase.babdeusilbun.repository.UserRepository;
 import com.zerobase.babdeusilbun.service.PurchaseService;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PurchaseServiceImpl implements PurchaseService {
 
-  private final PurchaseRepository purchaseRepository;
   private final UserRepository userRepository;
   private final MeetingRepository meetingRepository;
+  private final PurchaseRepository purchaseRepository;
+  private final TeamPurchaseRepository teamPurchaseRepository;
 
+  /**
+   * 주문 전 공동 주문 장바구니 조회
+   */
   @Override
   public TeamPurchaseResponse getTeamOrderCart(Long userId, Long meetingId, Pageable pageable) {
 
+    User findUser = findUserById(userId);
+    Meeting findMeeting = findMeetingById(meetingId);
 
+    // 해당 모임의 참가자 인지 확인
+    verifyMeetingParticipant(findUser, findMeeting);
 
-    return null;
+    // 해당 모임이 함께 식사 모임인지 확인
+    verifyDiningTogether(findMeeting);
+
+    // 주문 전 모임인지 확인
+    if (findMeeting.getStatus() != GATHERING) {
+      throw new CustomException(MEETING_STATUS_INVALID);
+    }
+
+    return mapToPurchaseResponse(teamPurchaseRepository.findAllByMeeting(findMeeting, pageable));
+  }
+
+  private TeamPurchaseResponse mapToPurchaseResponse(Page<TeamPurchase> teamPurchaseList) {
+
+    Pageable pageable = teamPurchaseList.getPageable();
+
+    Long totalPrice = getTeamTotalPrice(teamPurchaseList.getContent());
+    List<Item> itemList = getResponseItemList(teamPurchaseList.getContent());
+
+    return TeamPurchaseResponse.builder()
+        .totalFee(totalPrice)
+        .items(new PageImpl<>(itemList, pageable, teamPurchaseList.getTotalElements()))
+        .build();
+  }
+
+  private long getTeamTotalPrice(List<TeamPurchase> teamPurchaseList) {
+    return teamPurchaseList.stream()
+        .mapToLong(teampurchase -> teampurchase.getQuantity() * teampurchase.getMenu().getPrice())
+        .sum();
+  }
+
+  private List<Item> getResponseItemList(List<TeamPurchase> teamPurchaseList) {
+    return teamPurchaseList.stream().map(teamPurchase -> {
+          Menu menu = teamPurchase.getMenu();
+          return fromMenuEntity(teamPurchase, menu);
+        })
+        .toList();
+  }
+
+  private Item fromMenuEntity(TeamPurchase purchase, Menu menu) {
+    return Item.builder()
+        .purchaseId(purchase.getId())
+        .menuId(menu.getId())
+        .name(menu.getName())
+        .image(menu.getImage())
+        .description(menu.getDescription())
+        .price(menu.getPrice())
+        .quantity(purchase.getQuantity())
+        .build();
+  }
+
+  private void verifyDiningTogether(Meeting findMeeting) {
+    if (findMeeting.getPurchaseType() == PurchaseType.DINING_TOGETHER) {
+      throw new CustomException(MEETING_TYPE_INVALID);
+    }
+  }
+
+  private void verifyMeetingParticipant(User findUser, Meeting findMeeting) {
+    if (!purchaseRepository.existsByUserAndMeeting(findUser, findMeeting)) {
+      throw new CustomException(MEETING_PARTICIPANT_NOT_MATCH);
+    }
   }
 
   private User findUserById(Long userId) {
     return userRepository.findById(userId)
         .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+  }
+
+  private Meeting findMeetingById(Long meetingId) {
+    return meetingRepository.findById(meetingId)
+        .orElseThrow(() -> new CustomException(MEETING_NOT_FOUND));
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
@@ -1,8 +1,17 @@
 package com.zerobase.babdeusilbun.service.impl;
 
+import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
+
+import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.PurchaseDto.TeamPurchaseResponse;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.exception.ErrorCode;
+import com.zerobase.babdeusilbun.repository.MeetingRepository;
 import com.zerobase.babdeusilbun.repository.PurchaseRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
 import com.zerobase.babdeusilbun.service.PurchaseService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,5 +19,19 @@ import org.springframework.stereotype.Service;
 public class PurchaseServiceImpl implements PurchaseService {
 
   private final PurchaseRepository purchaseRepository;
+  private final UserRepository userRepository;
+  private final MeetingRepository meetingRepository;
 
+  @Override
+  public TeamPurchaseResponse getTeamOrderCart(Long userId, Long meetingId, Pageable pageable) {
+
+
+
+    return null;
+  }
+
+  private User findUserById(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+  }
 }

--- a/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
@@ -7,13 +7,16 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+import com.zerobase.babdeusilbun.domain.IndividualPurchase;
 import com.zerobase.babdeusilbun.domain.Meeting;
 import com.zerobase.babdeusilbun.domain.Menu;
+import com.zerobase.babdeusilbun.domain.Purchase;
 import com.zerobase.babdeusilbun.domain.TeamPurchase;
 import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse.Item;
 import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.repository.IndividualPurchaseRepository;
 import com.zerobase.babdeusilbun.repository.MeetingRepository;
 import com.zerobase.babdeusilbun.repository.PurchaseRepository;
 import com.zerobase.babdeusilbun.repository.TeamPurchaseRepository;
@@ -43,6 +46,8 @@ class PurchaseServiceImplTest {
   private MeetingRepository meetingRepository;
   @Mock
   private PurchaseRepository purchaseRepository;
+  @Mock
+  private IndividualPurchaseRepository individualPurchaseRepository;
   @Mock
   private TeamPurchaseRepository teamPurchaseRepository;
 
@@ -152,6 +157,126 @@ class PurchaseServiceImplTest {
     // when
     CustomException customException = assertThrows(CustomException.class,
         () -> purchaseService.getTeamPurchaseCart(1L, 1L, pageable));
+
+    // then
+    assertThat(customException.getErrorCode()).isEqualTo(MEETING_STATUS_INVALID);
+  }
+
+
+  @Test
+  @DisplayName("주문 전 개별 주문 장바구니 조회 - 성공")
+  void successGetIndividualOrderCart() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DELIVERY_TOGETHER).build();
+    Menu menu = Menu.builder().id(1L).price(1000L).build();
+    Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
+    IndividualPurchase individualPurchase =
+        IndividualPurchase.builder().id(1L).purchase(purchase).quantity(2).menu(menu).build();
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<IndividualPurchase> page = new PageImpl<>(List.of(individualPurchase), pageable, 1);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
+    when(purchaseRepository.findByMeetingAndUser(meeting, user)).thenReturn(Optional.of(purchase));
+    when(individualPurchaseRepository.findAllByPurchase(purchase, pageable)).thenReturn(page);
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
+
+    // when
+    PurchaseResponse result = purchaseService.getIndividualPurchaseCart(1L, 1L, pageable);
+    Page<Item> itemPage = result.getItems();
+    Item item = itemPage.getContent().getFirst();
+
+    // then
+    assertThat(result.getTotalFee()).isEqualTo(2000);
+    assertThat(itemPage.getTotalPages()).isEqualTo(1);
+    assertThat(itemPage.getSize()).isEqualTo(3);
+    assertThat(itemPage.getTotalElements()).isEqualTo(1);
+    assertThat(itemPage.getContent().size()).isEqualTo(1);
+    assertThat(item.getPurchaseId()).isEqualTo(individualPurchase.getId());
+    assertThat(item.getMenuId()).isEqualTo(menu.getId());
+    assertThat(item.getName()).isEqualTo(menu.getName());
+    assertThat(item.getPrice()).isEqualTo(menu.getPrice());
+    assertThat(item.getDescription()).isEqualTo(menu.getDescription());
+    assertThat(item.getQuantity()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("주문 전 개별 주문 장바구니 조회 - 실패 - 참가자 아님")
+  void failGetIndividualOrderCart_not_participant() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DELIVERY_TOGETHER).build();
+    Menu menu = Menu.builder().id(1L).price(1000L).build();
+    Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
+    IndividualPurchase individualPurchase =
+        IndividualPurchase.builder().id(1L).purchase(purchase).quantity(2).menu(menu).build();
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<IndividualPurchase> page = new PageImpl<>(List.of(individualPurchase), pageable, 1);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
+    when(purchaseRepository.findByMeetingAndUser(meeting, user)).thenReturn(Optional.of(purchase));
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(false);
+//    when(individualPurchaseRepository.findAllByPurchase(purchase, pageable)).thenReturn(page);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> purchaseService.getIndividualPurchaseCart(1L, 1L, pageable));
+
+    // then
+    assertThat(customException.getErrorCode()).isEqualTo(MEETING_PARTICIPANT_NOT_MATCH);
+  }
+
+  @Test
+  @DisplayName("주문 전 개별 주문 장바구니 조회 - 실패 - 함께 주문 아님")
+  void failGetIndividualOrderCart_not_delivery_together() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DINING_TOGETHER).build();
+    Menu menu = Menu.builder().id(1L).price(1000L).build();
+    Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
+    IndividualPurchase individualPurchase =
+        IndividualPurchase.builder().id(1L).purchase(purchase).quantity(2).menu(menu).build();
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<IndividualPurchase> page = new PageImpl<>(List.of(individualPurchase), pageable, 1);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
+    when(purchaseRepository.findByMeetingAndUser(meeting, user)).thenReturn(Optional.of(purchase));
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
+//    when(individualPurchaseRepository.findAllByPurchase(purchase, pageable)).thenReturn(page);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> purchaseService.getIndividualPurchaseCart(1L, 1L, pageable));
+
+    // then
+    assertThat(customException.getErrorCode()).isEqualTo(MEETING_TYPE_INVALID);
+  }
+
+  @Test
+  @DisplayName("주문 전 개별 주문 장바구니 조회 - 실패 - 주문 전 모임 아님")
+  void failGetIndividualOrderCart_not_before_order() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Meeting meeting = Meeting.builder().id(1L).status(PURCHASE_COMPLETED).purchaseType(DELIVERY_TOGETHER).build();
+    Menu menu = Menu.builder().id(1L).price(1000L).build();
+    Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
+    IndividualPurchase individualPurchase =
+        IndividualPurchase.builder().id(1L).purchase(purchase).quantity(2).menu(menu).build();
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<IndividualPurchase> page = new PageImpl<>(List.of(individualPurchase), pageable, 1);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
+    when(purchaseRepository.findByMeetingAndUser(meeting, user)).thenReturn(Optional.of(purchase));
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
+//    when(individualPurchaseRepository.findAllByPurchase(purchase, pageable)).thenReturn(page);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> purchaseService.getIndividualPurchaseCart(1L, 1L, pageable));
 
     // then
     assertThat(customException.getErrorCode()).isEqualTo(MEETING_STATUS_INVALID);

--- a/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
@@ -11,12 +11,9 @@ import com.zerobase.babdeusilbun.domain.Meeting;
 import com.zerobase.babdeusilbun.domain.Menu;
 import com.zerobase.babdeusilbun.domain.TeamPurchase;
 import com.zerobase.babdeusilbun.domain.User;
-import com.zerobase.babdeusilbun.dto.PurchaseDto.TeamPurchaseResponse;
-import com.zerobase.babdeusilbun.dto.PurchaseDto.TeamPurchaseResponse.Item;
-import com.zerobase.babdeusilbun.enums.MeetingStatus;
-import com.zerobase.babdeusilbun.enums.PurchaseType;
+import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse;
+import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse.Item;
 import com.zerobase.babdeusilbun.exception.CustomException;
-import com.zerobase.babdeusilbun.exception.ErrorCode;
 import com.zerobase.babdeusilbun.repository.MeetingRepository;
 import com.zerobase.babdeusilbun.repository.PurchaseRepository;
 import com.zerobase.babdeusilbun.repository.TeamPurchaseRepository;
@@ -24,7 +21,6 @@ import com.zerobase.babdeusilbun.repository.UserRepository;
 import com.zerobase.babdeusilbun.service.impl.PurchaseServiceImpl;
 import java.util.List;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -65,10 +61,10 @@ class PurchaseServiceImplTest {
     when(userRepository.findById(1L)).thenReturn(Optional.of(user));
     when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
     when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
-    when(purchaseRepository.existsByUserAndMeeting(user, meeting)).thenReturn(true);
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
 
     // when
-    TeamPurchaseResponse result = purchaseService.getTeamOrderCart(1L, 1L, pageable);
+    PurchaseResponse result = purchaseService.getTeamPurchaseCart(1L, 1L, pageable);
     Page<Item> itemPage = result.getItems();
     Item item = itemPage.getContent().getFirst();
 
@@ -100,12 +96,12 @@ class PurchaseServiceImplTest {
 
     when(userRepository.findById(1L)).thenReturn(Optional.of(user));
     when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
-    when(purchaseRepository.existsByUserAndMeeting(user, meeting)).thenReturn(false);
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(false);
 //    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
 
     // when
     CustomException customException = assertThrows(CustomException.class,
-        () -> purchaseService.getTeamOrderCart(1L, 1L, pageable));
+        () -> purchaseService.getTeamPurchaseCart(1L, 1L, pageable));
 
     // then
     assertThat(customException.getErrorCode()).isEqualTo(MEETING_PARTICIPANT_NOT_MATCH);
@@ -125,12 +121,12 @@ class PurchaseServiceImplTest {
 
     when(userRepository.findById(1L)).thenReturn(Optional.of(user));
     when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
-    when(purchaseRepository.existsByUserAndMeeting(user, meeting)).thenReturn(true);
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
 //    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
 
     // when
     CustomException customException = assertThrows(CustomException.class,
-        () -> purchaseService.getTeamOrderCart(1L, 1L, pageable));
+        () -> purchaseService.getTeamPurchaseCart(1L, 1L, pageable));
 
     // then
     assertThat(customException.getErrorCode()).isEqualTo(MEETING_TYPE_INVALID);
@@ -150,12 +146,12 @@ class PurchaseServiceImplTest {
 
     when(userRepository.findById(1L)).thenReturn(Optional.of(user));
     when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
-    when(purchaseRepository.existsByUserAndMeeting(user, meeting)).thenReturn(true);
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
 //    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
 
     // when
     CustomException customException = assertThrows(CustomException.class,
-        () -> purchaseService.getTeamOrderCart(1L, 1L, pageable));
+        () -> purchaseService.getTeamPurchaseCart(1L, 1L, pageable));
 
     // then
     assertThat(customException.getErrorCode()).isEqualTo(MEETING_STATUS_INVALID);

--- a/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
@@ -1,0 +1,165 @@
+package com.zerobase.babdeusilbun.service;
+
+import static com.zerobase.babdeusilbun.enums.MeetingStatus.*;
+import static com.zerobase.babdeusilbun.enums.PurchaseType.*;
+import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.zerobase.babdeusilbun.domain.Meeting;
+import com.zerobase.babdeusilbun.domain.Menu;
+import com.zerobase.babdeusilbun.domain.TeamPurchase;
+import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.PurchaseDto.TeamPurchaseResponse;
+import com.zerobase.babdeusilbun.dto.PurchaseDto.TeamPurchaseResponse.Item;
+import com.zerobase.babdeusilbun.enums.MeetingStatus;
+import com.zerobase.babdeusilbun.enums.PurchaseType;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.exception.ErrorCode;
+import com.zerobase.babdeusilbun.repository.MeetingRepository;
+import com.zerobase.babdeusilbun.repository.PurchaseRepository;
+import com.zerobase.babdeusilbun.repository.TeamPurchaseRepository;
+import com.zerobase.babdeusilbun.repository.UserRepository;
+import com.zerobase.babdeusilbun.service.impl.PurchaseServiceImpl;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseServiceImplTest {
+
+  @InjectMocks
+  private PurchaseServiceImpl purchaseService;
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private MeetingRepository meetingRepository;
+  @Mock
+  private PurchaseRepository purchaseRepository;
+  @Mock
+  private TeamPurchaseRepository teamPurchaseRepository;
+
+  @Test
+  @DisplayName("주문 전 공동 주문 장바구니 조회 - 성공")
+  void successGetTeamOrderCart() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DINING_TOGETHER).build();
+    Menu menu = Menu.builder().id(1L).price(1000L).build();
+    TeamPurchase teamPurchase =
+        TeamPurchase.builder().id(1L).meeting(meeting).quantity(2).menu(menu).build();
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<TeamPurchase> page = new PageImpl<>(List.of(teamPurchase), pageable, 1);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
+    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
+    when(purchaseRepository.existsByUserAndMeeting(user, meeting)).thenReturn(true);
+
+    // when
+    TeamPurchaseResponse result = purchaseService.getTeamOrderCart(1L, 1L, pageable);
+    Page<Item> itemPage = result.getItems();
+    Item item = itemPage.getContent().getFirst();
+
+    // then
+    assertThat(result.getTotalFee()).isEqualTo(2000);
+    assertThat(itemPage.getTotalPages()).isEqualTo(1);
+    assertThat(itemPage.getSize()).isEqualTo(3);
+    assertThat(itemPage.getTotalElements()).isEqualTo(1);
+    assertThat(itemPage.getContent().size()).isEqualTo(1);
+    assertThat(item.getPurchaseId()).isEqualTo(teamPurchase.getId());
+    assertThat(item.getMenuId()).isEqualTo(menu.getId());
+    assertThat(item.getName()).isEqualTo(menu.getName());
+    assertThat(item.getPrice()).isEqualTo(menu.getPrice());
+    assertThat(item.getDescription()).isEqualTo(menu.getDescription());
+    assertThat(item.getQuantity()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("주문 전 공동 주문 장바구니 조회 - 실패 - 참가자 아님")
+  void failGetTeamOrderCart_not_participant() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).build();
+    Menu menu = Menu.builder().id(1L).price(1000L).build();
+    TeamPurchase teamPurchase =
+        TeamPurchase.builder().id(1L).meeting(meeting).quantity(2).menu(menu).build();
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<TeamPurchase> page = new PageImpl<>(List.of(teamPurchase), pageable, 1);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
+    when(purchaseRepository.existsByUserAndMeeting(user, meeting)).thenReturn(false);
+//    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> purchaseService.getTeamOrderCart(1L, 1L, pageable));
+
+    // then
+    assertThat(customException.getErrorCode()).isEqualTo(MEETING_PARTICIPANT_NOT_MATCH);
+  }
+
+  @Test
+  @DisplayName("주문 전 공동 주문 장바구니 조회 - 실패 - 함께 식사 모임 아님")
+  void failGetTeamOrderCart_not_dining_together() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Meeting meeting = Meeting.builder().id(1L).purchaseType(DELIVERY_TOGETHER).status(GATHERING).build();
+    Menu menu = Menu.builder().id(1L).price(1000L).build();
+    TeamPurchase teamPurchase =
+        TeamPurchase.builder().id(1L).meeting(meeting).quantity(2).menu(menu).build();
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<TeamPurchase> page = new PageImpl<>(List.of(teamPurchase), pageable, 1);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
+    when(purchaseRepository.existsByUserAndMeeting(user, meeting)).thenReturn(true);
+//    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> purchaseService.getTeamOrderCart(1L, 1L, pageable));
+
+    // then
+    assertThat(customException.getErrorCode()).isEqualTo(MEETING_TYPE_INVALID);
+  }
+
+  @Test
+  @DisplayName("주문 전 공동 주문 장바구니 조회 - 실패 - 주문 전 모임 아님")
+  void failGetTeamOrderCart_not_before_order() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Meeting meeting = Meeting.builder().id(1L).purchaseType(DINING_TOGETHER).status(MEETING_COMPLETED).build();
+    Menu menu = Menu.builder().id(1L).price(1000L).build();
+    TeamPurchase teamPurchase =
+        TeamPurchase.builder().id(1L).meeting(meeting).quantity(2).menu(menu).build();
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<TeamPurchase> page = new PageImpl<>(List.of(teamPurchase), pageable, 1);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
+    when(purchaseRepository.existsByUserAndMeeting(user, meeting)).thenReturn(true);
+//    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> purchaseService.getTeamOrderCart(1L, 1L, pageable));
+
+    // then
+    assertThat(customException.getErrorCode()).isEqualTo(MEETING_STATUS_INVALID);
+  }
+
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
주문 전 공동 주문 장바구니 조회 기능을 개발하였습니다.
주문 전 개별 주문 장바구니 조회 기능을 개발하였습니다.

- 주문 전 상황을 판단하기 위해 meeting status 가 GATHERING인지 검증하였습니다.
- 공동 주문, 개별 주문을 구별하기 위해 meeting의 purchase type을 확인하도록 하였습니다.
- 쿼리 최적화를 위해 레포지토리의 메서드에 @EntityGraph를 적용하였습니다.


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
   - mockito를 사용해 성공, 실패 시나리오를 테스트 하였습니다.
- [ ] API 테스트 