### PR TITLE
fix : 메뉴 수정 요청 DTO에서 불필요한 어노테이션 제거,  로그인한 사용자 상세정보(페이지) 요청 시 식별번호(userId)도 반환하도록 변경

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/dto/MenuDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/MenuDto.java
@@ -41,15 +41,9 @@ public class MenuDto {
     @NoArgsConstructor
     @EqualsAndHashCode
     public static class UpdateRequest {
-        @NotBlank(message = "name 항목은 빈값이 올 수 없습니다.")
         private String name;
-
-        @NotBlank(message = "description 항목은 빈값이 올 수 없습니다.")
         private String description;
-
         private String image;
-
-        @PositiveOrZero(message = "price 항목은 0이상만 올 수 있습니다.")
         private long price;
 
         public Menu toEntity(Store store) {

--- a/src/main/java/com/zerobase/babdeusilbun/dto/UserDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/UserDto.java
@@ -46,6 +46,7 @@ public class UserDto {
   }
 
   public interface MyPage {
+    Long getUserId();
     String getName();
     String getNickname();
     String getPhoneNumber();

--- a/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/UserRepository.java
@@ -17,7 +17,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByIdAndDeletedAtIsNull(Long userId);
   
   @Query(value=
-          "select user.email as email, user.name as name, user.nickname as nickname, user.phoneNumber as phoneNumber, " +
+          "select user.id as userId, user.email as email, user.name as name, user.nickname as nickname, user.phoneNumber as phoneNumber, " +
                   "user.bankAccount as bankAccount, user.point as point, user.address as address, user.image as image, user.isBanned as isBanned," +
                   " ifnull(count(purchase.id), 0) as meetingCount, school.name as school, school.campus as campus, major.name as major \n" +
                   "from com.zerobase.babdeusilbun.domain.User as user \n" +


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 메뉴 수정 요청 DTO에서 값을 입력받지 않아도 처리되도록 되어있었는데 값을 반드시 입력하도록 요청되는 항목들이 있었습니다.
- 프론트엔드 개발 측에서 로그인한 사용자의 상세정보(페이지) 요청시 식별번호(userId)가 필요하다는 의견이 있었습니다.
 
**TO-BE**

- 메뉴 수정 요청 DTO에서 불필요한 어노테이션을 제거하였습니다.

- 로그인한 사용자의 상세정보(페이지) 요청시 식별번호(userId)도 반환되도록 수정하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 