### PR TITLE
feature: 주문 전 모임 배달비, 주문 가능 상점 조회

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
@@ -51,7 +51,18 @@ public class PurchaseController {
   /**
    * 주문 전 모임 배달비 조회
    */
-//  @PreAuthorize("hasRole('USER')")
+  @PreAuthorize("hasRole('USER')")
+  @GetMapping("delivery-fee")
+  public ResponseEntity<DeliveryFeeResponse> getDeliveryFeeInfo(
+      @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long meetingId
+  ) {
+
+    return ResponseEntity.ok(purchaseService.getDeliveryFeeInfo(userDetails.getId(), meetingId));
+  }
 
 
 }
+
+
+
+

--- a/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/PurchaseController.java
@@ -27,12 +27,11 @@ public class PurchaseController {
   @PreAuthorize("hasRole('USER')")
   @GetMapping("/team-order")
   public ResponseEntity<PurchaseResponse> getTeamPurchaseCart(
-      @AuthenticationPrincipal CustomUserDetails userDetails,
       @PathVariable Long meetingId, Pageable pageable
   ) {
 
     return ResponseEntity.ok(
-        purchaseService.getTeamPurchaseCart(userDetails.getId(), meetingId, pageable));
+        purchaseService.getTeamPurchaseCart(meetingId, pageable));
   }
 
   /**
@@ -48,5 +47,11 @@ public class PurchaseController {
     return ResponseEntity.ok(
         purchaseService.getIndividualPurchaseCart(userDetails.getId(), meetingId, pageable));
   }
+
+  /**
+   * 주문 전 모임 배달비 조회
+   */
+//  @PreAuthorize("hasRole('USER')")
+
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
@@ -263,7 +263,7 @@ public class StoreController {
    * 주문 가능 가게 리스트 검색/조회
    */
   @GetMapping("/users/stores")
-  public ResponseEntity<Page<StoreDto>> getAvailStoreList(
+  public ResponseEntity<Page<StoreDto.Information>> getAvailStoreList(
       @RequestParam("foodCategoryFilter") List<Long> categoryList,
       @RequestParam String searchMenu,
       @RequestParam Long schoolId,

--- a/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
@@ -16,6 +16,7 @@ import com.zerobase.babdeusilbun.service.StoreService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -256,5 +257,22 @@ public class StoreController {
     storeService.updateStoreInformation(entrepreneur.getId(), storeId, request);
 
     return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 주문 가능 가게 리스트 검색/조회
+   */
+  @GetMapping("/users/stores")
+  public ResponseEntity<Page<StoreDto>> getAvailStoreList(
+      @RequestParam("foodCategoryFilter") List<Long> categoryList,
+      @RequestParam String searchMenu,
+      @RequestParam Long schoolId,
+      @RequestParam String sortCriteria,
+      Pageable pageable
+  ) {
+
+    return ResponseEntity.ok(
+        storeService.getAvailStoreList(categoryList, searchMenu, schoolId, sortCriteria, pageable)
+    );
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/PurchaseDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/PurchaseDto.java
@@ -36,5 +36,15 @@ public class PurchaseDto {
   }
 
 
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @Builder
+  public static class DeliveryFeeResponse {
+    private Long price;
+    private Long fee;
+  }
+
+
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
@@ -6,6 +6,7 @@ import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.StoreImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,7 +22,7 @@ public class StoreDto {
     private Long storeId;
     private Long entrepreneurId;
     private String name;
-    private Page<StoreImageDto> image;
+    private List<StoreImageDto> image;
     private String description;
     private long minPurchasePrice;
     private String deliveryTimeRange;
@@ -31,12 +32,12 @@ public class StoreDto {
     private LocalTime openTime;
     private LocalTime closeTime;
 
-    public static Information fromEntity(Store store, Page<StoreImageDto> image) {
+    public static Information fromEntity(Store store, List<StoreImage> imageList) {
       return Information.builder()
           .storeId(store.getId())
           .entrepreneurId(store.getEntrepreneur().getId())
           .name(store.getName())
-          .image(image)
+          .image(imageList.stream().map(StoreImageDto::fromEntity).toList())
           .description(store.getDescription())
           .minPurchasePrice(store.getMinPurchaseAmount())
           .deliveryTimeRange(store.getMinDeliveryTime() + "분 ~ " + store.getMaxDeliveryTime() + "분")

--- a/src/main/java/com/zerobase/babdeusilbun/enums/SortCriteria.java
+++ b/src/main/java/com/zerobase/babdeusilbun/enums/SortCriteria.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import lombok.Getter;
 
 @Getter
-public enum MeetingSortCriteria {
+public enum SortCriteria {
 
   DEADLINE("deadline", "결제 마감 시간 순"),
   DELIVERY_TIME("shipping-time", "배송시간 순"),
@@ -17,13 +17,13 @@ public enum MeetingSortCriteria {
   private final String parameter;
   private final String description;
 
-  MeetingSortCriteria(String parameter, String description) {
+  SortCriteria(String parameter, String description) {
     this.parameter = parameter;
     this.description = description;
   }
 
-  public static MeetingSortCriteria fromParameter(String parameter) {
-    return Arrays.stream(MeetingSortCriteria.values())
+  public static SortCriteria fromParameter(String parameter) {
+    return Arrays.stream(SortCriteria.values())
         .filter(p -> p.getParameter().equals(parameter)).findFirst()
         .orElseThrow(() -> new CustomException(PARAMETER_INVALID));
   }

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
   // 주문 관련
   PURCHASE_NOT_FOUND(NOT_FOUND, "couldn't find purchase"),
   PURCHASE_PAYMENT_NOT_FOUND(NOT_FOUND, "couldn't find purchase snapshot"),
+  PURCHASE_STATUS_CANCEL(NOT_FOUND, "this participant cancel that purchase"),
 
   // 상점 관련
   STORE_NOT_FOUND(NOT_FOUND, "couldn't find store"),

--- a/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MeetingRepository.java
@@ -5,6 +5,7 @@ import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.repository.custom.CustomMeetingRepository;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,5 +22,9 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long>, CustomM
       + "where p.user = :participant "
       + "and m.status != 'MEETING_CANCELLED' and m.status != 'MEETING_COMPLETED' ")
   List<Meeting> findProceedingByParticipant(User participant);
+
+  @Query("select m from Meeting m where m.id = :id")
+  @EntityGraph(attributePaths = "store")
+  Optional<Meeting> findWithStoreById(Long id);
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/PurchaseRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/PurchaseRepository.java
@@ -35,4 +35,6 @@ public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
 
   boolean existsByMeetingAndUser(Meeting meeting, User user);
 
+  Long countAllByMeeting(Meeting meeting);
+
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/PurchaseRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/PurchaseRepository.java
@@ -35,6 +35,9 @@ public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
 
   boolean existsByMeetingAndUser(Meeting meeting, User user);
 
-  Long countAllByMeeting(Meeting meeting);
+  @Query("select count(p) "
+        + "from Purchase p "
+        + "where p.status <> 'CANCEL' and p.meeting = :meeting")
+  Long countParticipantByMeeting(Meeting meeting);
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
@@ -3,12 +3,13 @@ package com.zerobase.babdeusilbun.repository;
 import com.zerobase.babdeusilbun.domain.Address;
 import com.zerobase.babdeusilbun.domain.Entrepreneur;
 import com.zerobase.babdeusilbun.domain.Store;
+import com.zerobase.babdeusilbun.repository.custom.CustomStoreRepository;
 import java.util.Optional;
 import java.util.OptionalInt;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StoreRepository extends JpaRepository<Store, Long> {
+public interface StoreRepository extends JpaRepository<Store, Long>, CustomStoreRepository {
   boolean existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
       Entrepreneur entrepreneur, String name, Address address);
 

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomStoreRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomStoreRepository.java
@@ -1,0 +1,14 @@
+package com.zerobase.babdeusilbun.repository.custom;
+
+import com.zerobase.babdeusilbun.domain.Store;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomStoreRepository {
+
+  Page<Store> getAvailStoreList(
+      List<Long> categoryList, String searchMenu,
+      Long schoolId, String sortCriteria, Pageable pageable);
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomMeetingRepositoryImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomMeetingRepositoryImpl.java
@@ -9,7 +9,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zerobase.babdeusilbun.domain.Meeting;
-import com.zerobase.babdeusilbun.enums.MeetingSortCriteria;
+import com.zerobase.babdeusilbun.enums.SortCriteria;
 import com.zerobase.babdeusilbun.repository.custom.CustomMeetingRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -106,7 +106,7 @@ public class CustomMeetingRepositoryImpl implements CustomMeetingRepository {
 
     List<OrderSpecifier<?>> list = new ArrayList<>();
 
-    switch (MeetingSortCriteria.fromParameter(sortParameter)) {
+    switch (SortCriteria.fromParameter(sortParameter)) {
       case DEADLINE -> list.add(orderDeadline());
       case DELIVERY_TIME -> list.add(orderDeliveryTime());
       case DELIVERY_FEE -> list.add(orderDeliveryFee());

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomStoreRepositoryImpl.java
@@ -39,6 +39,8 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
         .join(school).on(storeSchool.school.eq(school))
         .join(menu).on(menu.store.eq(store))
         .where(school.id.eq(schoolId))
+        .where(store.deletedAt.isNull())
+        .where(menu.deletedAt.isNull())
         .where(where(categoryList, searchMenu))
         .orderBy(getOrderSpecifier(sortCriteria))
         .offset(pageable.getOffset())
@@ -52,6 +54,8 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
         .join(storeSchool).on(storeSchool.store.eq(store))
         .join(school).on(storeSchool.school.eq(school))
         .join(menu).on(menu.store.eq(store))
+        .where(store.deletedAt.isNull())
+        .where(menu.deletedAt.isNull())
         .where(school.id.eq(schoolId))
         .where(where(categoryList, searchMenu))
         .fetchOne();

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomStoreRepositoryImpl.java
@@ -1,0 +1,108 @@
+package com.zerobase.babdeusilbun.repository.custom.impl;
+
+import static com.zerobase.babdeusilbun.domain.QCategory.*;
+import static com.zerobase.babdeusilbun.domain.QMenu.*;
+import static com.zerobase.babdeusilbun.domain.QSchool.*;
+import static com.zerobase.babdeusilbun.domain.QStore.*;
+import static com.zerobase.babdeusilbun.domain.QStoreCategory.*;
+import static com.zerobase.babdeusilbun.domain.QStoreSchool.*;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.babdeusilbun.domain.Store;
+import com.zerobase.babdeusilbun.enums.SortCriteria;
+import com.zerobase.babdeusilbun.repository.custom.CustomStoreRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomStoreRepositoryImpl implements CustomStoreRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<Store> getAvailStoreList(List<Long> categoryList, String searchMenu, Long schoolId,
+      String sortCriteria, Pageable pageable) {
+
+    List<Store> storeList = queryFactory.selectFrom(store)
+        .join(storeCategory).on(storeCategory.store.eq(store))
+        .join(category).on(storeCategory.category.eq(category))
+        .join(storeSchool).on(storeSchool.store.eq(store))
+        .join(school).on(storeSchool.school.eq(school))
+        .join(menu).on(menu.store.eq(store))
+        .where(school.id.eq(schoolId))
+        .where(where(categoryList, searchMenu))
+        .orderBy(getOrderSpecifier(sortCriteria))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    Long count = queryFactory
+        .select(store.count()).from(store)
+        .join(storeCategory).on(storeCategory.store.eq(store))
+        .join(category).on(storeCategory.category.eq(category))
+        .join(storeSchool).on(storeSchool.store.eq(store))
+        .join(school).on(storeSchool.school.eq(school))
+        .join(menu).on(menu.store.eq(store))
+        .where(school.id.eq(schoolId))
+        .where(where(categoryList, searchMenu))
+        .fetchOne();
+
+
+    return new PageImpl<>(storeList, pageable, count);
+  }
+
+  private BooleanExpression[] where(List<Long> categoryList, String searchMenu) {
+    List<BooleanExpression> list = new ArrayList<>();
+
+    if (!categoryList.isEmpty()) {
+      list.add(filterCategory(categoryList));
+    }
+
+    if (StringUtils.hasText(searchMenu)) {
+      list.add(searchMenuName(searchMenu));
+    }
+
+    return list.toArray(new BooleanExpression[0]);
+  }
+
+  private OrderSpecifier<?>[] getOrderSpecifier(String sortCriteria) {
+    List<OrderSpecifier<?>> list = new ArrayList<>();
+
+    switch (SortCriteria.valueOf(sortCriteria)) {
+      case DELIVERY_TIME -> list.add(orderByDeliveryTime());
+      case DELIVERY_FEE -> list.add(orderByDeliveryFee());
+      case MIN_PRICE -> list.add(orderByMinPrice());
+    }
+
+    return list.toArray(new OrderSpecifier[0]);
+  }
+
+  private BooleanExpression filterCategory(List<Long> categoryList) {
+    return category.id.in(categoryList);
+  }
+
+  private BooleanExpression searchMenuName(String searchMenu) {
+    return menu.name.like(searchMenu);
+  }
+
+  private OrderSpecifier<?> orderByDeliveryTime() {
+    return store.minDeliveryTime.asc();
+  }
+
+  private OrderSpecifier<?> orderByDeliveryFee() {
+    return store.deliveryPrice.asc();
+  }
+
+  private OrderSpecifier<?> orderByMinPrice() {
+    return store.minPurchaseAmount.asc();
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface PurchaseService {
 
-  PurchaseResponse getTeamPurchaseCart(Long userId, Long meetingId, Pageable pageable);
+  PurchaseResponse getTeamPurchaseCart(Long meetingId, Pageable pageable);
 
 
   PurchaseResponse getIndividualPurchaseCart(Long userId, Long meetingId, Pageable pageable);

--- a/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/PurchaseService.java
@@ -1,5 +1,6 @@
 package com.zerobase.babdeusilbun.service;
 
+import com.zerobase.babdeusilbun.dto.PurchaseDto.DeliveryFeeResponse;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +11,5 @@ public interface PurchaseService {
 
   PurchaseResponse getIndividualPurchaseCart(Long userId, Long meetingId, Pageable pageable);
 
+  DeliveryFeeResponse getDeliveryFeeInfo(Long userId, Long meetingId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
@@ -9,6 +9,7 @@ import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
 import com.zerobase.babdeusilbun.dto.StoreImageDto;
 import java.util.List;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface StoreService {
@@ -24,4 +25,7 @@ public interface StoreService {
   boolean deleteImageOnStore(Long entrepreneurId, Long storeId, Long imageId);
   void updateStoreImage(Long entrepreneurId, Long storeId, Long imageId, StoreImageDto.UpdateRequest request);
   void updateStoreInformation(Long entrepreneurId, Long storeId, StoreDto.UpdateRequest request);
+
+  Page<StoreDto> getAvailStoreList
+      (List<Long> categoryList, String searchMenu, Long schoolId, String sortCriteria, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
@@ -26,6 +26,6 @@ public interface StoreService {
   void updateStoreImage(Long entrepreneurId, Long storeId, Long imageId, StoreImageDto.UpdateRequest request);
   void updateStoreInformation(Long entrepreneurId, Long storeId, StoreDto.UpdateRequest request);
 
-  Page<StoreDto> getAvailStoreList
+  Page<StoreDto.Information> getAvailStoreList
       (List<Long> categoryList, String searchMenu, Long schoolId, String sortCriteria, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
@@ -93,15 +93,17 @@ public class PurchaseServiceImpl implements PurchaseService {
   public DeliveryFeeResponse getDeliveryFeeInfo(Long userId, Long meetingId) {
 
     User findUser = findUserById(userId);
-    Meeting findMeeting = findMeetingById(meetingId);
+    Meeting findMeeting = meetingRepository.findWithStoreById(meetingId)
+        .orElseThrow(() -> new CustomException(MEETING_NOT_FOUND));
+
+    // 모임이 주문 전 상태인지 확인
+    verifyBeforeOrder(findMeeting);
 
     // 해당 모임의 참가자 인지 확인
     verifyMeetingParticipant(findUser, findMeeting);
 
     // 해당 모임의 상점의 배송비 가져옴
-    Long deliveryPrice = meetingRepository.findWithStoreById(meetingId)
-        .orElseThrow(() -> new CustomException(MEETING_NOT_FOUND))
-        .getStore().getDeliveryPrice();
+    Long deliveryPrice = findMeeting.getStore().getDeliveryPrice();
 
     // 개인 별 배송비 가져옴
     Long participantCount = purchaseRepository.countParticipantByMeeting(findMeeting);

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
@@ -1,6 +1,7 @@
 package com.zerobase.babdeusilbun.service.impl;
 
 import static com.zerobase.babdeusilbun.enums.MeetingStatus.*;
+import static com.zerobase.babdeusilbun.enums.PurchaseStatus.*;
 import static com.zerobase.babdeusilbun.enums.PurchaseType.*;
 import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
 
@@ -14,7 +15,9 @@ import com.zerobase.babdeusilbun.dto.PurchaseDto;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.DeliveryFeeResponse;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse.Item;
+import com.zerobase.babdeusilbun.enums.PurchaseStatus;
 import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.exception.ErrorCode;
 import com.zerobase.babdeusilbun.repository.IndividualPurchaseRepository;
 import com.zerobase.babdeusilbun.repository.MeetingRepository;
 import com.zerobase.babdeusilbun.repository.PurchaseRepository;
@@ -70,6 +73,9 @@ public class PurchaseServiceImpl implements PurchaseService {
     // 해당 모임의 참가자 인지 확인
     verifyMeetingParticipant(findUser, findMeeting);
 
+    // 주문 취소 상태가 아닌지 확인
+    verifyPurchaseCancel(findPurchase);
+
     // 해당 모임이 함께 배달 모임인지 확인
     verifyDeliveryTogether(findMeeting);
 
@@ -98,7 +104,7 @@ public class PurchaseServiceImpl implements PurchaseService {
         .getStore().getDeliveryPrice();
 
     // 개인 별 배송비 가져옴
-    Long participantCount = purchaseRepository.countAllByMeeting(findMeeting);
+    Long participantCount = purchaseRepository.countParticipantByMeeting(findMeeting);
     // 일의 자리는 버림
     Integer deliveryFee = (int) ((deliveryPrice / participantCount) / 10) * 10;
 
@@ -210,6 +216,12 @@ public class PurchaseServiceImpl implements PurchaseService {
   private void verifyBeforeOrder(Meeting findMeeting) {
     if (findMeeting.getStatus() != GATHERING) {
       throw new CustomException(MEETING_STATUS_INVALID);
+    }
+  }
+
+  private void verifyPurchaseCancel(Purchase findPurchase) {
+    if (findPurchase.getStatus() == CANCEL) {
+      throw new CustomException(PURCHASE_STATUS_CANCEL);
     }
   }
 

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
@@ -10,6 +10,7 @@ import com.zerobase.babdeusilbun.domain.Menu;
 import com.zerobase.babdeusilbun.domain.Purchase;
 import com.zerobase.babdeusilbun.domain.TeamPurchase;
 import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.PurchaseDto.DeliveryFeeResponse;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse.Item;
 import com.zerobase.babdeusilbun.exception.CustomException;
@@ -76,6 +77,14 @@ public class PurchaseServiceImpl implements PurchaseService {
 
     return mapToIndividualResponse(
         individualPurchaseRepository.findAllByPurchase(findPurchase, pageable));
+  }
+
+  /**
+   * 주문 전 모임 배달비 조회
+   */
+  @Override
+  public DeliveryFeeResponse getDeliveryFeeInfo(Long userId, Long meetingId) {
+    return null;
   }
 
   private PurchaseResponse mapToIndividualResponse

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/PurchaseServiceImpl.java
@@ -42,13 +42,9 @@ public class PurchaseServiceImpl implements PurchaseService {
    * 주문 전 공동 주문 장바구니 조회
    */
   @Override
-  public PurchaseResponse getTeamPurchaseCart(Long userId, Long meetingId, Pageable pageable) {
+  public PurchaseResponse getTeamPurchaseCart(Long meetingId, Pageable pageable) {
 
-    User findUser = findUserById(userId);
     Meeting findMeeting = findMeetingById(meetingId);
-
-    // 해당 모임의 참가자 인지 확인
-    verifyMeetingParticipant(findUser, findMeeting);
 
     // 해당 모임이 함께 식사 모임인지 확인
     verifyDiningTogether(findMeeting);

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
@@ -1,11 +1,7 @@
 package com.zerobase.babdeusilbun.service.impl;
 
-import static com.zerobase.babdeusilbun.exception.ErrorCode.ALREADY_EXIST_STORE;
-import static com.zerobase.babdeusilbun.exception.ErrorCode.ENTREPRENEUR_NOT_FOUND;
-import static com.zerobase.babdeusilbun.exception.ErrorCode.NO_AUTH_ON_STORE;
-import static com.zerobase.babdeusilbun.exception.ErrorCode.NO_IMAGE_ON_STORE;
-import static com.zerobase.babdeusilbun.exception.ErrorCode.STORE_IMAGE_NOT_FOUND;
-import static com.zerobase.babdeusilbun.exception.ErrorCode.STORE_NOT_FOUND;
+import static com.zerobase.babdeusilbun.dto.StoreDto.*;
+import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
 import static com.zerobase.babdeusilbun.util.ImageUtility.STORE_IMAGE_FOLDER;
 
 import com.zerobase.babdeusilbun.component.ImageComponent;
@@ -23,9 +19,6 @@ import com.zerobase.babdeusilbun.dto.CategoryDto.Information;
 import com.zerobase.babdeusilbun.dto.HolidayDto.HolidaysRequest;
 import com.zerobase.babdeusilbun.dto.SchoolDto;
 import com.zerobase.babdeusilbun.dto.StoreDto;
-import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
-import com.zerobase.babdeusilbun.dto.StoreDto.IdResponse;
-import com.zerobase.babdeusilbun.dto.StoreDto.ImageUrl;
 import com.zerobase.babdeusilbun.dto.StoreImageDto.UpdateRequest;
 import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.repository.CategoryRepository;
@@ -55,6 +48,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @AllArgsConstructor
 public class StoreServiceImpl implements StoreService {
+
   private final EntrepreneurRepository entrepreneurRepository;
   private final StoreRepository storeRepository;
   private final StoreImageRepository imageRepository;
@@ -64,27 +58,32 @@ public class StoreServiceImpl implements StoreService {
   private final StoreCategoryRepository storeCategoryRepository;
   private final HolidayRepository holidayRepository;
   private final ImageComponent imageComponent;
+  private final StoreImageRepository storeImageRepository;
 
   public Object[] checkEntities(Long entrepreneurId, Long storeId) {
     Entrepreneur entrepreneur = entrepreneurRepository
-        .findByIdAndDeletedAtIsNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+        .findByIdAndDeletedAtIsNull(entrepreneurId)
+        .orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
 
     Store store = storeRepository
-        .findByIdAndDeletedAtIsNull(storeId).orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
+        .findByIdAndDeletedAtIsNull(storeId)
+        .orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
 
     if (store.getEntrepreneur() != entrepreneur) {
       throw new CustomException(NO_AUTH_ON_STORE);
     }
 
-    return new Object[] {entrepreneur, store};
+    return new Object[]{entrepreneur, store};
   }
 
   public Object[] checkEntities(Long entrepreneurId, Long storeId, Long imageId) {
     Entrepreneur entrepreneur = entrepreneurRepository
-        .findByIdAndDeletedAtIsNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+        .findByIdAndDeletedAtIsNull(entrepreneurId)
+        .orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
 
     Store store = storeRepository
-        .findByIdAndDeletedAtIsNull(storeId).orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
+        .findByIdAndDeletedAtIsNull(storeId)
+        .orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
 
     StoreImage image = imageRepository.findById(imageId)
         .orElseThrow(() -> new CustomException(STORE_IMAGE_NOT_FOUND));
@@ -97,14 +96,15 @@ public class StoreServiceImpl implements StoreService {
       throw new CustomException(NO_IMAGE_ON_STORE);
     }
 
-    return new Object[] {entrepreneur, store, image};
+    return new Object[]{entrepreneur, store, image};
   }
 
   @Override
   @Transactional
   public IdResponse createStore(Long entrepreneurId, CreateRequest request) {
     Entrepreneur entrepreneur = entrepreneurRepository
-        .findByIdAndDeletedAtIsNull(entrepreneurId).orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+        .findByIdAndDeletedAtIsNull(entrepreneurId)
+        .orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
 
     if (storeRepository.existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
         entrepreneur, request.getName(), request.getAddress().toEntity())
@@ -256,8 +256,8 @@ public class StoreServiceImpl implements StoreService {
       }
 
       holidayRepository.save(Holiday.builder()
-              .store(store)
-              .dayOfWeek(dayOfWeek)
+          .store(store)
+          .dayOfWeek(dayOfWeek)
           .build());
 
       count.getAndIncrement();
@@ -286,7 +286,8 @@ public class StoreServiceImpl implements StoreService {
     imageRepository.findAllByStoreOrderBySequenceAsc(store)
         .forEach(storeImage -> {
           if (!Objects.equals(storeImage.getId(), imageId)) {
-            storeImage.update(image.getIsRepresentative() && count.get() == 0, count.getAndIncrement());
+            storeImage.update(image.getIsRepresentative() && count.get() == 0,
+                count.getAndIncrement());
 
             return;
           }
@@ -307,7 +308,8 @@ public class StoreServiceImpl implements StoreService {
 
   @Override
   @Transactional
-  public void updateStoreImage(Long entrepreneurId, Long storeId, Long imageId, UpdateRequest request) {
+  public void updateStoreImage(Long entrepreneurId, Long storeId, Long imageId,
+      UpdateRequest request) {
     Object[] entities = checkEntities(entrepreneurId, storeId, imageId);
     Store store = (Store) entities[1];
     StoreImage image = (StoreImage) entities[2];
@@ -316,7 +318,8 @@ public class StoreServiceImpl implements StoreService {
     if (request.getSequence() != null && request.getSequence().equals(image.getSequence())) {
       request.setSequence(null);
     }
-    if (request.getIsRepresentative() != null && request.getIsRepresentative().equals(image.getIsRepresentative())) {
+    if (request.getIsRepresentative() != null && request.getIsRepresentative()
+        .equals(image.getIsRepresentative())) {
       request.setIsRepresentative(null);
     }
 
@@ -332,12 +335,12 @@ public class StoreServiceImpl implements StoreService {
 
   private void updateImageSequence(StoreImage cur, int sequence, List<StoreImage> images) {
     if (cur.getSequence() < sequence) {
-      for (int i = cur.getSequence()+1; i <= Math.min(sequence, images.size()-1); i++) {
-        images.get(i).update(null, images.get(i).getSequence()-1);
+      for (int i = cur.getSequence() + 1; i <= Math.min(sequence, images.size() - 1); i++) {
+        images.get(i).update(null, images.get(i).getSequence() - 1);
       }
     } else if (cur.getSequence() > sequence) {
       for (int i = Math.max(0, sequence); i < cur.getSequence(); i++) {
-        images.get(i).update(null, images.get(i).getSequence()+1);
+        images.get(i).update(null, images.get(i).getSequence() + 1);
       }
     }
 
@@ -347,7 +350,7 @@ public class StoreServiceImpl implements StoreService {
   private void updateImageRepresentative(StoreImage cur, List<StoreImage> images) {
     boolean curRepresentative = cur.getIsRepresentative();
 
-    for(StoreImage image: images) {
+    for (StoreImage image : images) {
       if (image != cur && image.getIsRepresentative() != curRepresentative) {
         image.update(!image.getIsRepresentative(), null);
 
@@ -360,18 +363,21 @@ public class StoreServiceImpl implements StoreService {
 
   @Override
   @Transactional
-  public void updateStoreInformation(Long entrepreneurId, Long storeId, StoreDto.UpdateRequest request) {
+  public void updateStoreInformation(Long entrepreneurId, Long storeId,
+      StoreDto.UpdateRequest request) {
     Object[] entities = checkEntities(entrepreneurId, storeId);
     Store store = (Store) entities[1];
 
     if (request.getCategoryIds() != null) {
-      enrollToCategory(entrepreneurId, storeId, new CategoryDto.IdsRequest(request.getCategoryIds()));
+      enrollToCategory(entrepreneurId, storeId,
+          new CategoryDto.IdsRequest(request.getCategoryIds()));
 
       storeCategoryRepository.deleteByStoreAndCategory_IdNotIn(store, request.getCategoryIds());
     }
 
     if (request.getSchoolIds() != null) {
-      enrollSchoolsToStore(entrepreneurId, storeId, new SchoolDto.IdsRequest(request.getSchoolIds()));
+      enrollSchoolsToStore(entrepreneurId, storeId,
+          new SchoolDto.IdsRequest(request.getSchoolIds()));
 
       storeSchoolRepository.deleteByStoreAndSchool_IdNotIn(store, request.getSchoolIds());
     }
@@ -380,22 +386,19 @@ public class StoreServiceImpl implements StoreService {
   }
 
   @Override
-  @Transactional
-  public Page<StoreDto> getAvailStoreList(
+  @Transactional(readOnly = true)
+  public Page<StoreDto.Information> getAvailStoreList(
       List<Long> categoryList, String searchMenu,
       Long schoolId, String sortCriteria, Pageable pageable) {
 
-    Page<Store> availStoreList = storeRepository.getAvailStoreList(categoryList, searchMenu,
-        schoolId, sortCriteria, pageable);
-
-    return null;
+    return storeRepository
+        .getAvailStoreList(categoryList, searchMenu, schoolId, sortCriteria, pageable)
+        .map(this::mapToStoreDto);
   }
 
   private StoreDto.Information mapToStoreDto(Store store) {
-
-    List<StoreImage> storeImageList = imageRepository.findAllByStoreOrderBySequenceAsc(store);
-
-//    return StoreDto.Information.fromEntity(store, storeImageList::);
-    return null;
+    return StoreDto.Information.fromEntity(
+        store, storeImageRepository.findAllByStoreOrderBySequenceAsc(store)
+    );
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/StoreServiceImpl.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -376,5 +377,25 @@ public class StoreServiceImpl implements StoreService {
     }
 
     store.update(request);
+  }
+
+  @Override
+  @Transactional
+  public Page<StoreDto> getAvailStoreList(
+      List<Long> categoryList, String searchMenu,
+      Long schoolId, String sortCriteria, Pageable pageable) {
+
+    Page<Store> availStoreList = storeRepository.getAvailStoreList(categoryList, searchMenu,
+        schoolId, sortCriteria, pageable);
+
+    return null;
+  }
+
+  private StoreDto.Information mapToStoreDto(Store store) {
+
+    List<StoreImage> storeImageList = imageRepository.findAllByStoreOrderBySequenceAsc(store);
+
+//    return StoreDto.Information.fromEntity(store, storeImageList::);
+    return null;
   }
 }

--- a/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
@@ -55,7 +55,6 @@ class PurchaseServiceImplTest {
   @DisplayName("주문 전 공동 주문 장바구니 조회 - 성공")
   void successGetTeamOrderCart() throws Exception {
     // given
-    User user = User.builder().id(1L).build();
     Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DINING_TOGETHER).build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     TeamPurchase teamPurchase =
@@ -63,13 +62,12 @@ class PurchaseServiceImplTest {
     Pageable pageable = PageRequest.of(0, 3);
     Page<TeamPurchase> page = new PageImpl<>(List.of(teamPurchase), pageable, 1);
 
-    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
     when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
     when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
-    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
+//    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
 
     // when
-    PurchaseResponse result = purchaseService.getTeamPurchaseCart(1L, 1L, pageable);
+    PurchaseResponse result = purchaseService.getTeamPurchaseCart(1L, pageable);
     Page<Item> itemPage = result.getItems();
     Item item = itemPage.getContent().getFirst();
 
@@ -88,35 +86,9 @@ class PurchaseServiceImplTest {
   }
 
   @Test
-  @DisplayName("주문 전 공동 주문 장바구니 조회 - 실패 - 참가자 아님")
-  void failGetTeamOrderCart_not_participant() throws Exception {
-    // given
-    User user = User.builder().id(1L).build();
-    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).build();
-    Menu menu = Menu.builder().id(1L).price(1000L).build();
-    TeamPurchase teamPurchase =
-        TeamPurchase.builder().id(1L).meeting(meeting).quantity(2).menu(menu).build();
-    Pageable pageable = PageRequest.of(0, 3);
-    Page<TeamPurchase> page = new PageImpl<>(List.of(teamPurchase), pageable, 1);
-
-    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-    when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
-    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(false);
-//    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
-
-    // when
-    CustomException customException = assertThrows(CustomException.class,
-        () -> purchaseService.getTeamPurchaseCart(1L, 1L, pageable));
-
-    // then
-    assertThat(customException.getErrorCode()).isEqualTo(MEETING_PARTICIPANT_NOT_MATCH);
-  }
-
-  @Test
   @DisplayName("주문 전 공동 주문 장바구니 조회 - 실패 - 함께 식사 모임 아님")
   void failGetTeamOrderCart_not_dining_together() throws Exception {
     // given
-    User user = User.builder().id(1L).build();
     Meeting meeting = Meeting.builder().id(1L).purchaseType(DELIVERY_TOGETHER).status(GATHERING).build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     TeamPurchase teamPurchase =
@@ -124,14 +96,12 @@ class PurchaseServiceImplTest {
     Pageable pageable = PageRequest.of(0, 3);
     Page<TeamPurchase> page = new PageImpl<>(List.of(teamPurchase), pageable, 1);
 
-    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
     when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
-    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
 //    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
 
     // when
     CustomException customException = assertThrows(CustomException.class,
-        () -> purchaseService.getTeamPurchaseCart(1L, 1L, pageable));
+        () -> purchaseService.getTeamPurchaseCart(1L, pageable));
 
     // then
     assertThat(customException.getErrorCode()).isEqualTo(MEETING_TYPE_INVALID);
@@ -141,7 +111,6 @@ class PurchaseServiceImplTest {
   @DisplayName("주문 전 공동 주문 장바구니 조회 - 실패 - 주문 전 모임 아님")
   void failGetTeamOrderCart_not_before_order() throws Exception {
     // given
-    User user = User.builder().id(1L).build();
     Meeting meeting = Meeting.builder().id(1L).purchaseType(DINING_TOGETHER).status(MEETING_COMPLETED).build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     TeamPurchase teamPurchase =
@@ -149,14 +118,12 @@ class PurchaseServiceImplTest {
     Pageable pageable = PageRequest.of(0, 3);
     Page<TeamPurchase> page = new PageImpl<>(List.of(teamPurchase), pageable, 1);
 
-    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
     when(meetingRepository.findById(1L)).thenReturn(Optional.of(meeting));
-    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
 //    when(teamPurchaseRepository.findAllByMeeting(meeting, pageable)).thenReturn(page);
 
     // when
     CustomException customException = assertThrows(CustomException.class,
-        () -> purchaseService.getTeamPurchaseCart(1L, 1L, pageable));
+        () -> purchaseService.getTeamPurchaseCart(1L, pageable));
 
     // then
     assertThat(customException.getErrorCode()).isEqualTo(MEETING_STATUS_INVALID);

--- a/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/PurchaseServiceImplTest.java
@@ -6,14 +6,17 @@ import static com.zerobase.babdeusilbun.enums.PurchaseType.*;
 import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.zerobase.babdeusilbun.domain.IndividualPurchase;
 import com.zerobase.babdeusilbun.domain.Meeting;
 import com.zerobase.babdeusilbun.domain.Menu;
 import com.zerobase.babdeusilbun.domain.Purchase;
+import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.TeamPurchase;
 import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.PurchaseDto.DeliveryFeeResponse;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse;
 import com.zerobase.babdeusilbun.dto.PurchaseDto.PurchaseResponse.Item;
 import com.zerobase.babdeusilbun.enums.PurchaseStatus;
@@ -21,6 +24,7 @@ import com.zerobase.babdeusilbun.exception.CustomException;
 import com.zerobase.babdeusilbun.repository.IndividualPurchaseRepository;
 import com.zerobase.babdeusilbun.repository.MeetingRepository;
 import com.zerobase.babdeusilbun.repository.PurchaseRepository;
+import com.zerobase.babdeusilbun.repository.StoreRepository;
 import com.zerobase.babdeusilbun.repository.TeamPurchaseRepository;
 import com.zerobase.babdeusilbun.repository.UserRepository;
 import com.zerobase.babdeusilbun.service.impl.PurchaseServiceImpl;
@@ -52,12 +56,15 @@ class PurchaseServiceImplTest {
   private IndividualPurchaseRepository individualPurchaseRepository;
   @Mock
   private TeamPurchaseRepository teamPurchaseRepository;
+  @Mock
+  private StoreRepository storeRepository;
 
   @Test
   @DisplayName("주문 전 공동 주문 장바구니 조회 - 성공")
   void successGetTeamOrderCart() throws Exception {
     // given
-    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DINING_TOGETHER).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DINING_TOGETHER)
+        .build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     TeamPurchase teamPurchase =
         TeamPurchase.builder().id(1L).meeting(meeting).quantity(2).menu(menu).build();
@@ -91,7 +98,8 @@ class PurchaseServiceImplTest {
   @DisplayName("주문 전 공동 주문 장바구니 조회 - 실패 - 함께 식사 모임 아님")
   void failGetTeamOrderCart_not_dining_together() throws Exception {
     // given
-    Meeting meeting = Meeting.builder().id(1L).purchaseType(DELIVERY_TOGETHER).status(GATHERING).build();
+    Meeting meeting = Meeting.builder().id(1L).purchaseType(DELIVERY_TOGETHER).status(GATHERING)
+        .build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     TeamPurchase teamPurchase =
         TeamPurchase.builder().id(1L).meeting(meeting).quantity(2).menu(menu).build();
@@ -113,7 +121,8 @@ class PurchaseServiceImplTest {
   @DisplayName("주문 전 공동 주문 장바구니 조회 - 실패 - 주문 전 모임 아님")
   void failGetTeamOrderCart_not_before_order() throws Exception {
     // given
-    Meeting meeting = Meeting.builder().id(1L).purchaseType(DINING_TOGETHER).status(MEETING_COMPLETED).build();
+    Meeting meeting = Meeting.builder().id(1L).purchaseType(DINING_TOGETHER)
+        .status(MEETING_COMPLETED).build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     TeamPurchase teamPurchase =
         TeamPurchase.builder().id(1L).meeting(meeting).quantity(2).menu(menu).build();
@@ -137,7 +146,8 @@ class PurchaseServiceImplTest {
   void successGetIndividualOrderCart() throws Exception {
     // given
     User user = User.builder().id(1L).build();
-    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DELIVERY_TOGETHER).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DELIVERY_TOGETHER)
+        .build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
     IndividualPurchase individualPurchase =
@@ -175,7 +185,8 @@ class PurchaseServiceImplTest {
   void failGetIndividualOrderCart_not_participant() throws Exception {
     // given
     User user = User.builder().id(1L).build();
-    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DELIVERY_TOGETHER).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DELIVERY_TOGETHER)
+        .build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
     IndividualPurchase individualPurchase =
@@ -202,7 +213,8 @@ class PurchaseServiceImplTest {
   void failGetIndividualOrderCart_not_delivery_together() throws Exception {
     // given
     User user = User.builder().id(1L).build();
-    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DINING_TOGETHER).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DINING_TOGETHER)
+        .build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
     IndividualPurchase individualPurchase =
@@ -229,7 +241,8 @@ class PurchaseServiceImplTest {
   void failGetIndividualOrderCart_not_before_order() throws Exception {
     // given
     User user = User.builder().id(1L).build();
-    Meeting meeting = Meeting.builder().id(1L).status(PURCHASE_COMPLETED).purchaseType(DELIVERY_TOGETHER).build();
+    Meeting meeting = Meeting.builder().id(1L).status(PURCHASE_COMPLETED)
+        .purchaseType(DELIVERY_TOGETHER).build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
     Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
     IndividualPurchase individualPurchase =
@@ -256,9 +269,11 @@ class PurchaseServiceImplTest {
   void failGetIndividualOrderCart_not_cancel_purchase() throws Exception {
     // given
     User user = User.builder().id(1L).build();
-    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DELIVERY_TOGETHER).build();
+    Meeting meeting = Meeting.builder().id(1L).status(GATHERING).purchaseType(DELIVERY_TOGETHER)
+        .build();
     Menu menu = Menu.builder().id(1L).price(1000L).build();
-    Purchase purchase = Purchase.builder().id(1L).meeting(meeting).status(CANCEL).user(user).build();
+    Purchase purchase = Purchase.builder().id(1L).meeting(meeting).status(CANCEL).user(user)
+        .build();
     IndividualPurchase individualPurchase =
         IndividualPurchase.builder().id(1L).purchase(purchase).quantity(2).menu(menu).build();
     Pageable pageable = PageRequest.of(0, 3);
@@ -276,6 +291,78 @@ class PurchaseServiceImplTest {
 
     // then
     assertThat(customException.getErrorCode()).isEqualTo(PURCHASE_STATUS_CANCEL);
+  }
+
+  @Test
+  @DisplayName("주문 전 모임 배달비 조회 - 성공")
+  void successGetDeliveryFee() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Store store = Store.builder().id(1L).deliveryPrice(10000L).build();
+    Meeting meeting = Meeting.builder().id(1L).store(store)
+        .status(GATHERING).purchaseType(DELIVERY_TOGETHER).build();
+    Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
+
+    // when
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findWithStoreById(1L)).thenReturn(Optional.of(meeting));
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
+//    when(purchaseRepository.findByMeetingAndUser(meeting, user)).thenReturn(Optional.of(purchase));
+    when(purchaseRepository.countParticipantByMeeting(meeting)).thenReturn(3L);
+
+    DeliveryFeeResponse result = purchaseService.getDeliveryFeeInfo(1L, 1L);
+
+    // then
+    assertThat(result.getPrice()).isEqualTo(10000L);
+    assertThat(result.getFee()).isEqualTo(3330L);
+  }
+
+  @Test
+  @DisplayName("주문 전 모임 배달비 조회 - 실패 - 모임이 주문 전 아님")
+  void failGetDeliveryFee_meeting_not_before_order() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Store store = Store.builder().id(1L).deliveryPrice(10000L).build();
+    Meeting meeting = Meeting.builder().id(1L).store(store)
+        .status(MEETING_COMPLETED).purchaseType(DELIVERY_TOGETHER).build();
+    Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
+
+    // when
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findWithStoreById(1L)).thenReturn(Optional.of(meeting));
+//    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(true);
+//    when(purchaseRepository.findByMeetingAndUser(meeting, user)).thenReturn(Optional.of(purchase));
+//    when(purchaseRepository.countParticipantByMeeting(meeting)).thenReturn(3L);
+
+    CustomException customException = assertThrows(CustomException.class,
+        () -> purchaseService.getDeliveryFeeInfo(1L, 1L));
+
+    // then
+    assertThat(customException.getErrorCode()).isEqualTo(MEETING_STATUS_INVALID);
+  }
+
+  @Test
+  @DisplayName("주문 전 모임 배달비 조회 - 실패 - 해당 모임 참가자 아님")
+  void failGetDeliveryFee_meeting_not_participant() throws Exception {
+    // given
+    User user = User.builder().id(1L).build();
+    Store store = Store.builder().id(1L).deliveryPrice(10000L).build();
+    Meeting meeting = Meeting.builder().id(1L).store(store)
+        .status(GATHERING).purchaseType(DELIVERY_TOGETHER).build();
+    Purchase purchase = Purchase.builder().id(1L).meeting(meeting).user(user).build();
+
+    // when
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(meetingRepository.findWithStoreById(1L)).thenReturn(Optional.of(meeting));
+    when(purchaseRepository.existsByMeetingAndUser(meeting, user)).thenReturn(false);
+//    when(purchaseRepository.findByMeetingAndUser(meeting, user)).thenReturn(Optional.of(purchase));
+//    when(purchaseRepository.countParticipantByMeeting(meeting)).thenReturn(3L);
+
+    CustomException customException = assertThrows(CustomException.class,
+        () -> purchaseService.getDeliveryFeeInfo(1L, 1L));
+
+    // then
+    assertThat(customException.getErrorCode()).isEqualTo(MEETING_PARTICIPANT_NOT_MATCH);
   }
 
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
주문 전 모임 전체 배달비, 개인별 배달비 조회 기능을 구현하였습니다.
주문 가능 주문 가능 가게 리스트 검색/조회 기능을 구현하였습니다.
   - QueryDsl을 사용하여 동적인 파라미터에 대응하도록 하였습니다.
   - deletedAt 필드가 null이 아닌 엔티티는 검색 결과에서 제거하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 