### PR TITLE
feat : 사업자의 정보를 조회하거나 수정하는 서비스 생성

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/EntrepreneurController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/EntrepreneurController.java
@@ -1,0 +1,51 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.EntrepreneurService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
+
+@RestController
+@RequestMapping("/api/businesses")
+@RequiredArgsConstructor
+public class EntrepreneurController {
+
+    private final EntrepreneurService entrepreneurService;
+
+    /**
+     * 회원 정보 조회 (로그인한 사업가 정보 조회)
+     */
+    @PreAuthorize("hasRole('ENTREPRENEUR')")
+    @GetMapping("/infos")
+    public ResponseEntity<EntrepreneurDto.MyPage> getProfile(@AuthenticationPrincipal CustomUserDetails entrepreneur) {
+        EntrepreneurDto.MyPage myPage = entrepreneurService.getMyPage(entrepreneur.getId());
+
+        return ResponseEntity.ok(myPage);
+    }
+
+    /**
+     * 회원 정보 수정 (로그인한 사업가 정보 수정)
+     */
+    @PreAuthorize("hasRole('ENTREPRENEUR')")
+    @PatchMapping(value ="/infos",
+            consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<Void> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails entrepreneur,
+            @RequestPart(value = "file", required = false) MultipartFile image,
+            @RequestPart(value = "request") EntrepreneurDto.UpdateRequest request
+    ) {
+
+        EntrepreneurDto.UpdateRequest result = entrepreneurService.updateProfile(entrepreneur.getId(), image, request);
+
+        return (image != null && result.getImage() == null) ?
+                ResponseEntity.status(PARTIAL_CONTENT).build() : ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/domain/Entrepreneur.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/Entrepreneur.java
@@ -1,6 +1,7 @@
 package com.zerobase.babdeusilbun.domain;
 
 
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -57,4 +58,17 @@ public class Entrepreneur extends BaseEntity{
   }
 
 
+  public void update(EntrepreneurDto.UpdateRequest request) {
+    if (request.getPhoneNumber() != null) this.phoneNumber = request.getPhoneNumber();
+    if(request.getPostal() != null && request.getStreetAddress() != null && request.getDetailAddress() != null) {
+      this.address = address.builder()
+              .postal(request.getPostal())
+              .streetAddress(request.getStreetAddress())
+              .detailAddress(request.getDetailAddress())
+              .build();
+    }
+    if (request.getPassword() != null) this.password = request.getPassword();
+    if (request.getImage() != null) this.image = request.getImage();
+
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/EntrepreneurDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/EntrepreneurDto.java
@@ -1,0 +1,37 @@
+package com.zerobase.babdeusilbun.dto;
+
+import com.zerobase.babdeusilbun.domain.Address;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class EntrepreneurDto {
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateRequest {
+        private String phoneNumber;
+        private String postal;
+        private String streetAddress;
+        private String detailAddress;
+        private String image;
+        private String password;
+    }
+
+    public interface MyPage {
+        Long getEntrepreneurId();
+
+        String getEmail();
+
+        String getName();
+
+        String getPhoneNumber();
+        String getBusinessNumber();
+
+        Address getAddress();
+
+        String getImage();
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/repository/EntrepreneurRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/EntrepreneurRepository.java
@@ -1,8 +1,10 @@
 package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto.MyPage;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface EntrepreneurRepository extends JpaRepository<Entrepreneur, Long> {
 
@@ -11,4 +13,10 @@ public interface EntrepreneurRepository extends JpaRepository<Entrepreneur, Long
   Optional<Entrepreneur> findByEmail(String email);
 
   Optional<Entrepreneur> findByIdAndDeletedAtIsNull(Long entrepreneurId);
+
+  @Query(value = "select e.id as entrepreneurId, e.email as email, e.name as name, " +
+          "e.phoneNumber as phoneNumber, e.businessNumber as businessNumber, e.address as address, e.image as image " +
+          "from Entrepreneur as e " +
+          "where e.id = :entrepreneurId and e.deletedAt is null")
+  Optional<MyPage> findMyPageByUserId(Long entrepreneurId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/EntrepreneurService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/EntrepreneurService.java
@@ -1,0 +1,12 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto.MyPage;
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto.UpdateRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface EntrepreneurService {
+    MyPage getMyPage(Long entrepreneurId);
+
+    UpdateRequest updateProfile(Long entrepreneurId, MultipartFile image, UpdateRequest updateRequest);
+
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/UserService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/UserService.java
@@ -13,7 +13,7 @@ public interface UserService {
 
   UserDto.UpdateRequest updateProfile(Long userId, MultipartFile image, UserDto.UpdateRequest request);
 
-  UserDto.UpdateAddress updateAddress(Long userId, UserDto.UpdateAddress updateAddress);
+  Address updateAddress(Long userId, UserDto.UpdateAddress updateAddress);
 
   BankAccount updateAccount(Long id, UserDto.UpdateAccount updateAccount);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/EntrepreneurServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/EntrepreneurServiceImpl.java
@@ -1,0 +1,71 @@
+package com.zerobase.babdeusilbun.service.impl;
+
+import com.zerobase.babdeusilbun.component.ImageComponent;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto.MyPage;
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto.UpdateRequest;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.repository.EntrepreneurRepository;
+import com.zerobase.babdeusilbun.service.EntrepreneurService;
+import lombok.AllArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import io.micrometer.common.util.StringUtils;
+
+import java.util.List;
+
+import static com.zerobase.babdeusilbun.exception.ErrorCode.ENTREPRENEUR_NOT_FOUND;
+import static com.zerobase.babdeusilbun.util.ImageUtility.ENTREPRENEUR_IMAGE_FOLDER;
+
+@Service
+@AllArgsConstructor
+
+public class EntrepreneurServiceImpl implements EntrepreneurService {
+
+    private final EntrepreneurRepository entrepreneurRepository;
+
+    private final ImageComponent imageComponent;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public MyPage getMyPage(Long entrepreneurId) {
+        return entrepreneurRepository.findMyPageByUserId(entrepreneurId)
+                .orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional
+    public UpdateRequest updateProfile(Long entrepreneurId, MultipartFile image, UpdateRequest request) {
+        Entrepreneur entrepreneur = entrepreneurRepository.findByIdAndDeletedAtIsNull(entrepreneurId)
+                .orElseThrow(() -> new CustomException(ENTREPRENEUR_NOT_FOUND));
+
+        if (image != null) {
+            updateImage(entrepreneur, image, request);
+        } else if (request.getImage() != null && request.getImage().isEmpty() && StringUtils.isNotBlank(entrepreneur.getImage())) {
+            imageComponent.deleteImageByUrl(entrepreneur.getImage());
+        }
+
+        if (request.getPassword() != null) {
+            request.setPassword(passwordEncoder.encode(request.getPassword()));
+        }
+
+        entrepreneur.update(request);
+        return request;
+    }
+
+    private void updateImage(Entrepreneur entrepreneur, MultipartFile image, UpdateRequest request) {
+        List<String> uploadUrlList = imageComponent.uploadImageList(List.of(image), ENTREPRENEUR_IMAGE_FOLDER);
+        if (uploadUrlList.isEmpty()) {
+            request.setImage(null);
+            return;
+        }
+
+        if (StringUtils.isNotBlank(entrepreneur.getImage())) {
+            imageComponent.deleteImageByUrl(entrepreneur.getImage());
+        }
+
+        request.setImage(uploadUrlList.getFirst());
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
@@ -4,10 +4,7 @@ import static com.zerobase.babdeusilbun.exception.ErrorCode.USER_NOT_FOUND;
 import static com.zerobase.babdeusilbun.util.ImageUtility.USER_IMAGE_FOLDER;
 
 import com.zerobase.babdeusilbun.component.ImageComponent;
-import com.zerobase.babdeusilbun.domain.BankAccount;
-import com.zerobase.babdeusilbun.domain.Major;
-import com.zerobase.babdeusilbun.domain.School;
-import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.domain.*;
 import com.zerobase.babdeusilbun.dto.EvaluateDto;
 import com.zerobase.babdeusilbun.dto.UserDto;
 import com.zerobase.babdeusilbun.dto.UserDto.MyPage;
@@ -91,11 +88,11 @@ public class UserServiceImpl implements UserService {
   // 사용자의 주소 정보를 업데이트
   @Override
   @Transactional
-  public UpdateAddress updateAddress(Long userId, UpdateAddress updateAddress) {
+  public Address updateAddress(Long userId, UpdateAddress updateAddress) {
     User user = userRepository.findByIdAndDeletedAtIsNull(userId)
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
     user.updateAddress(updateAddress);
-    return updateAddress;
+    return user.getAddress();
   }
 
   @Override

--- a/src/main/java/com/zerobase/babdeusilbun/util/ImageUtility.java
+++ b/src/main/java/com/zerobase/babdeusilbun/util/ImageUtility.java
@@ -8,6 +8,7 @@ public class ImageUtility {
   public static final String MENU_IMAGE_FOLDER = "menu";
   public static final String STORE_IMAGE_FOLDER = "store";
   public static final String USER_IMAGE_FOLDER = "user";
+  public static final String ENTREPRENEUR_IMAGE_FOLDER = "entrepreneur";
   public static final String INQUIRY_IMAGE_FOLDER = "inquiry";
 
   public static boolean isImage(String imageFileName) {

--- a/src/test/java/com/zerobase/babdeusilbun/controller/EntrepreneurControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/EntrepreneurControllerTest.java
@@ -1,0 +1,134 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto;
+import com.zerobase.babdeusilbun.dto.MenuDto;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.EntrepreneurService;
+import com.zerobase.babdeusilbun.util.TestEntrepreneurUtility;
+import com.zerobase.babdeusilbun.util.TestMenuUtility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(EntrepreneurController.class)
+public class EntrepreneurControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EntrepreneurService entrepreneurService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private CustomUserDetails testEntrepreneur;
+
+    private EntrepreneurDto.UpdateRequest updateRequest = EntrepreneurDto.UpdateRequest.builder().phoneNumber("010")
+            .image("img").postal("p").streetAddress("s").detailAddress("d").password("pa").build();
+
+    private final EntrepreneurDto.UpdateRequest responseUpdateRequestNotImage = EntrepreneurDto.UpdateRequest.builder().phoneNumber("010")
+            .image(null).postal("p").streetAddress("s").detailAddress("d").password("pa").build();
+
+    @BeforeEach
+    void setUp() {
+        //로그인 정보 세팅
+        testEntrepreneur = TestEntrepreneurUtility.createTestEntrepreneur();
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(testEntrepreneur, null, testEntrepreneur.getAuthorities())
+        );
+    }
+
+    @DisplayName("정보 수정 컨트롤러 테스트(이미지 업로드 X, 완전 성공)")
+    @Test
+    void updateProfile() throws Exception {
+        //given
+        MockMultipartFile request = new MockMultipartFile(
+                "request", "request", "application/json",
+                objectMapper.writeValueAsString(updateRequest).getBytes());
+
+        // when
+        when(entrepreneurService.updateProfile(eq(testEntrepreneur.getId()), eq(null), eq(updateRequest)))
+                .thenReturn(updateRequest);
+
+        // then
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/businesses/infos")
+                        .file(request)
+                        .with(csrf())
+                        .with(httpRequest -> {
+                            httpRequest.setMethod("PATCH");
+                            return httpRequest;
+                        }))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("정보 수정 컨트롤러 테스트(이미지 업로드 성공)")
+    @Test
+    void updateProfileWithImageUploadSuccess() throws Exception {
+        //given
+        MockMultipartFile request = new MockMultipartFile(
+                "request", "request", "application/json",
+                objectMapper.writeValueAsString(updateRequest).getBytes());
+
+        MockMultipartFile image = new MockMultipartFile(
+                "file", "image.png", "image/png", "1".getBytes());
+
+        // when
+        when(entrepreneurService.updateProfile(eq(testEntrepreneur.getId()), eq(image), eq(updateRequest)))
+                .thenReturn(updateRequest);
+
+        // then
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/businesses/infos")
+                        .file(image)
+                        .file(request)
+                        .with(csrf())
+                        .with(httpRequest -> {
+                            httpRequest.setMethod("PATCH");
+                            return httpRequest;
+                        }))
+                .andExpect(status().isOk());
+    }
+
+
+    @DisplayName("정보 수정 컨트롤러 테스트(이미지 업로드 실패로 인한 부분 성공)")
+    @Test
+    void updateProfileWithImageUploadFail() throws Exception {
+        //given
+        MockMultipartFile request = new MockMultipartFile(
+                "request", "request", "application/json",
+                objectMapper.writeValueAsString(updateRequest).getBytes());
+
+        MockMultipartFile image = new MockMultipartFile(
+                "file", "image.png", "image/png", "1".getBytes());
+
+        // when
+        when(entrepreneurService.updateProfile(eq(testEntrepreneur.getId()), eq(image), eq(updateRequest)))
+                .thenReturn(responseUpdateRequestNotImage);
+
+        // then
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/businesses/infos")
+                        .file(image)
+                        .file(request)
+                        .with(csrf())
+                        .with(httpRequest -> {
+                            httpRequest.setMethod("PATCH");
+                            return httpRequest;
+                        }))
+                .andExpect(status().isPartialContent());
+    }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/controller/UserControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/UserControllerTest.java
@@ -118,8 +118,11 @@ public class UserControllerTest {
             "request", "request", "application/json",
             objectMapper.writeValueAsString(input).getBytes());
 
+    User user = TestUserUtility.getUser();
+    user.updateAddress(input);
+
     // when
-    when(userService.updateAddress(eq(testUser.getId()), eq(input))).thenReturn(input);
+    when(userService.updateAddress(eq(testUser.getId()), eq(input))).thenReturn(user.getAddress());
 
     // then
     mockMvc.perform(

--- a/src/test/java/com/zerobase/babdeusilbun/service/EntrepreneurServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/EntrepreneurServiceTest.java
@@ -1,0 +1,165 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.component.ImageComponent;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.domain.Major;
+import com.zerobase.babdeusilbun.domain.School;
+import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto;
+import com.zerobase.babdeusilbun.dto.UserDto;
+import com.zerobase.babdeusilbun.repository.EntrepreneurRepository;
+import com.zerobase.babdeusilbun.service.impl.EntrepreneurServiceImpl;
+import com.zerobase.babdeusilbun.util.TestEntrepreneurUtility;
+import com.zerobase.babdeusilbun.util.TestUserUtility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static com.zerobase.babdeusilbun.util.ImageUtility.ENTREPRENEUR_IMAGE_FOLDER;
+import static com.zerobase.babdeusilbun.util.ImageUtility.MENU_IMAGE_FOLDER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EntrepreneurServiceTest {
+    @Mock
+    private EntrepreneurRepository entrepreneurRepository;
+
+    @Mock
+    private ImageComponent imageComponent;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private EntrepreneurServiceImpl entrepreneurService;
+
+    private final MultipartFile testMultipartFile = new MultipartFile() {
+        @Override
+        public String getName() {
+            return "파일1";
+        }
+
+        @Override
+        public String getOriginalFilename() {
+            return "파일2";
+        }
+
+        @Override
+        public String getContentType() {
+            return "파일3";
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public long getSize() {
+            return 5;
+        }
+
+        @Override
+        public byte[] getBytes() throws IOException {
+            return new byte[0];
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return null;
+        }
+
+        @Override
+        public void transferTo(File dest) throws IOException, IllegalStateException {
+
+        }
+    };
+
+    @DisplayName("내 정보 수정 테스트 (이미지 업로드 X)")
+    @Test
+    void UpdateProfile() {
+        // given
+        Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
+        EntrepreneurDto.UpdateRequest request = new EntrepreneurDto.UpdateRequest(
+                "newNickname", "postal", "street", "detail", null, "1234abcd");
+
+        when(entrepreneurRepository.findByIdAndDeletedAtIsNull(eq(entrepreneur.getId()))).thenReturn(java.util.Optional.of(entrepreneur));
+        when(passwordEncoder.encode(eq(request.getPassword()))).thenReturn("encodedPassword");
+
+        // when
+        entrepreneurService.updateProfile(1L, null, request);
+
+        // then
+        assertEquals(request.getPhoneNumber(), entrepreneur.getPhoneNumber());
+        assertEquals(request.getPostal(), entrepreneur.getAddress().getPostal());
+        assertEquals(request.getStreetAddress(), entrepreneur.getAddress().getStreetAddress());
+        assertEquals(request.getDetailAddress(), entrepreneur.getAddress().getDetailAddress());
+        assertNotEquals(request.getImage(), entrepreneur.getImage());
+        assertEquals(request.getPassword(), entrepreneur.getPassword());
+    }
+
+    @DisplayName("내 정보 수정 테스트 (이미지 업로드)")
+    @Test
+    void UpdateProfileWithImageUploadSuccess() {
+        // given
+        Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
+        EntrepreneurDto.UpdateRequest request = new EntrepreneurDto.UpdateRequest(
+                "newNickname", "postal", "street", "detail", null, "1234abcd");
+
+
+        when(entrepreneurRepository.findByIdAndDeletedAtIsNull(eq(entrepreneur.getId()))).thenReturn(java.util.Optional.of(entrepreneur));
+        when(passwordEncoder.encode(eq(request.getPassword()))).thenReturn("encodedPassword");
+        when(imageComponent.uploadImageList(eq(List.of(testMultipartFile)), eq(ENTREPRENEUR_IMAGE_FOLDER)))
+                .thenReturn(List.of("new_image"));
+        // when
+        entrepreneurService.updateProfile(1L, testMultipartFile, request);
+
+        // then
+        assertEquals(request.getPhoneNumber(), entrepreneur.getPhoneNumber());
+        assertEquals(request.getPostal(), entrepreneur.getAddress().getPostal());
+        assertEquals(request.getStreetAddress(), entrepreneur.getAddress().getStreetAddress());
+        assertEquals(request.getDetailAddress(), entrepreneur.getAddress().getDetailAddress());
+        assertEquals(request.getImage(), "new_image");
+        assertEquals(entrepreneur.getImage(), "new_image");
+        assertEquals(request.getPassword(), entrepreneur.getPassword());
+    }
+
+    @DisplayName("내 정보 수정 테스트 (이미지 업로드 실패)")
+    @Test
+    void UpdateProfileWithImageUploadFail() {
+        // given
+        Entrepreneur entrepreneur = TestEntrepreneurUtility.getEntrepreneur();
+        EntrepreneurDto.UpdateRequest request = new EntrepreneurDto.UpdateRequest(
+                "newNickname", "postal", "street", "detail", "123", "1234abcd");
+
+
+        when(entrepreneurRepository.findByIdAndDeletedAtIsNull(eq(entrepreneur.getId()))).thenReturn(java.util.Optional.of(entrepreneur));
+        when(passwordEncoder.encode(eq(request.getPassword()))).thenReturn("encodedPassword");
+        when(imageComponent.uploadImageList(eq(List.of(testMultipartFile)), eq(ENTREPRENEUR_IMAGE_FOLDER)))
+                .thenReturn(List.of());
+        // when
+        entrepreneurService.updateProfile(1L, testMultipartFile, request);
+
+        // then
+        assertEquals(request.getPhoneNumber(), entrepreneur.getPhoneNumber());
+        assertEquals(request.getPostal(), entrepreneur.getAddress().getPostal());
+        assertEquals(request.getStreetAddress(), entrepreneur.getAddress().getStreetAddress());
+        assertEquals(request.getDetailAddress(), entrepreneur.getAddress().getDetailAddress());
+        assertEquals(request.getImage(), null);
+        assertNotEquals(entrepreneur.getImage(), null);
+        assertEquals(request.getPassword(), entrepreneur.getPassword());
+    }
+}

--- a/src/test/java/com/zerobase/babdeusilbun/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/UserServiceTest.java
@@ -85,7 +85,7 @@ public class UserServiceTest {
     when(userRepository.findByIdAndDeletedAtIsNull(eq(user.getId()))).thenReturn(java.util.Optional.of(user));
 
     // when
-    UpdateAddress address = userService.updateAddress(user.getId(), updateAddress);
+    Address address = userService.updateAddress(user.getId(), updateAddress);
 
     // then
     assertEquals(address.getPostal(), user.getAddress().getPostal());

--- a/src/test/java/com/zerobase/babdeusilbun/util/TestEntrepreneurUtility.java
+++ b/src/test/java/com/zerobase/babdeusilbun/util/TestEntrepreneurUtility.java
@@ -10,6 +10,7 @@ public class TestEntrepreneurUtility {
       .email("entrepreneur@test.com")
       .password("password")
       .name("가짜 사업가")
+      .image("가짜 이미지")
       .phoneNumber("00000000000")
       .businessNumber("0000000000")
       .address(Address.builder()


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 로그인한 사업가의 정보를 조회하거나 수정하는 기능이 구현되지 않았습니다.

**TO-BE**
- 로그인한 사업가의 정보를 조회하는 기능을 구현하였습니다.

- 정보를 조회할 때 식별번호, 이메일, 이름, 휴대폰번호, 사업번호, 주소, 이미지 주소가 조회되도록 구현하였습니다.

- 로그인한 사업가의 정보를 수정하는 기능을 구현하였습니다.

- 정보를 수정할 때 이미지 첨부, 비밀번호 변경도 가능하도록 구현하였습니다.

- 사업가의 이미지를 저장할 폴더 이름을 ImageUtility.java에 새로 추가하였습니다.

- 정보를 수정하는 과정이 잘 수행되는지 확인하기 위해 테스트코드를 작성 후 이상없이 작동됨을 확인하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 