### PR TITLE
feature: 사업가가 본인이 등록한 상점 목록 조회, 상점 삭제 기능 구현, refactor: 서비스단에서 중복된 레포지토리 정리, test: 추가된 기능 테스트코드 작성

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
@@ -275,4 +275,64 @@ public class StoreController {
         storeService.getAvailStoreList(categoryList, searchMenu, schoolId, sortCriteria, pageable)
     );
   }
+
+  /**
+   * 상점 삭제
+   */
+  @PreAuthorize("hasRole('ENTREPRENEUR')")
+  @DeleteMapping("/businesses/stores/{storeId}")
+  public ResponseEntity<Void> deleteStore(
+      @AuthenticationPrincipal CustomUserDetails entrepreneur,
+      @PathVariable("storeId") Long storeId
+  ) {
+    storeService.deleteStore(entrepreneur.getId(), storeId);
+
+    return ResponseEntity.status(NO_CONTENT).build();
+  }
+
+  /**
+   * 등록한 상점 리스트 조회
+   */
+  @PreAuthorize("hasRole('ENTREPRENEUR')")
+  @GetMapping("/businesses/stores")
+  public ResponseEntity<Page<StoreDto.SimpleInformation>> getAllStoresByEntrepreneur(
+      @AuthenticationPrincipal CustomUserDetails entrepreneur,
+      @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+      @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+      @RequestParam(name = "unprocessedOnly", required = false, defaultValue = "false") boolean unprocessedOnly) {
+    return ResponseEntity.ok(
+        storeService.getAllStoresByEntrepreneur(entrepreneur.getId(), page, size, unprocessedOnly));
+  }
+
+  /**
+   * 상점 정보 조회
+   */
+
+  /**
+   * 상점별 휴무일 조회
+   */
+
+  /**
+   * 상점별 카테고리 조회
+   */
+
+  /**
+   * 가게별 메뉴 리스트 조회
+   */
+
+  /**
+   * 상점별 사업자 정보 조회
+   */
+
+  /**
+   * 상점별 배달가능 캠퍼스 조회
+   */
+
+  /**
+   * 상점 이미지 전체 조회
+   */
+
+  /**
+   * 썸네일 조회
+   */
 }

--- a/src/main/java/com/zerobase/babdeusilbun/domain/Store.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/Store.java
@@ -104,4 +104,8 @@ public class Store extends BaseEntity{
       this.closeTime = request.getCloseTime();
     }
   }
+
+  public void delete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
@@ -1,6 +1,7 @@
 package com.zerobase.babdeusilbun.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.querydsl.core.annotations.QueryProjection;
 import com.zerobase.babdeusilbun.domain.Entrepreneur;
 import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.StoreImage;
@@ -130,5 +131,24 @@ public class StoreDto {
   @Builder
   public static class IdResponse {
     private Long storeId;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class SimpleInformation {
+    private Long storeId;
+    private String name;
+    private String image;
+    private int unprocessedPurchaseCount;
+
+    @QueryProjection
+    public SimpleInformation(Long storeId, String name, String image, Long unprocessedPurchaseCount) {
+      this.storeId = storeId;
+      this.name = name;
+      this.image = image;
+      this.unprocessedPurchaseCount = (unprocessedPurchaseCount == null) ? 0 : unprocessedPurchaseCount.intValue();
+    }
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreRepository.java
@@ -5,9 +5,10 @@ import com.zerobase.babdeusilbun.domain.Entrepreneur;
 import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.repository.custom.CustomStoreRepository;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StoreRepository extends JpaRepository<Store, Long>, CustomStoreRepository {
   boolean existsByEntrepreneurAndNameAndAddressAndDeletedAtIsNull(
       Entrepreneur entrepreneur, String name, Address address);

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomStoreRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/CustomStoreRepository.java
@@ -2,13 +2,16 @@ package com.zerobase.babdeusilbun.repository.custom;
 
 import com.zerobase.babdeusilbun.domain.Store;
 import java.util.List;
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.dto.StoreDto.SimpleInformation;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomStoreRepository {
-
   Page<Store> getAvailStoreList(
       List<Long> categoryList, String searchMenu,
       Long schoolId, String sortCriteria, Pageable pageable);
-
+  Page<SimpleInformation> getStorePageByEntrepreneur(
+      Entrepreneur entrepreneur, Pageable pageable, boolean unprocessedOnly);
+  Long getStoresCountByEntrepreneur(Entrepreneur entrepreneur, boolean unprocessedOnly);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomStoreRepositoryImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/custom/impl/CustomStoreRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.zerobase.babdeusilbun.repository.custom.impl;
 import static com.zerobase.babdeusilbun.domain.QCategory.*;
 import static com.zerobase.babdeusilbun.domain.QMenu.*;
 import static com.zerobase.babdeusilbun.domain.QSchool.*;
-import static com.zerobase.babdeusilbun.domain.QStore.*;
 import static com.zerobase.babdeusilbun.domain.QStoreCategory.*;
 import static com.zerobase.babdeusilbun.domain.QStoreSchool.*;
 
@@ -12,6 +11,15 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.enums.SortCriteria;
+import static com.querydsl.core.types.ExpressionUtils.count;
+
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import com.zerobase.babdeusilbun.domain.QMeeting;
+import com.zerobase.babdeusilbun.domain.QStore;
+import com.zerobase.babdeusilbun.domain.QStoreImage;
+import com.zerobase.babdeusilbun.dto.QStoreDto_SimpleInformation;
+import com.zerobase.babdeusilbun.dto.StoreDto.SimpleInformation;
+import com.zerobase.babdeusilbun.enums.MeetingStatus;
 import com.zerobase.babdeusilbun.repository.custom.CustomStoreRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,12 +29,17 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
 
 @Repository
 @RequiredArgsConstructor
 public class CustomStoreRepositoryImpl implements CustomStoreRepository {
-
   private final JPAQueryFactory queryFactory;
+
+  private final QStore store = QStore.store;
+  private final QStoreImage storeImage = QStoreImage.storeImage;
+  private final QMeeting meeting = QMeeting.meeting;
 
   @Override
   public Page<Store> getAvailStoreList(List<Long> categoryList, String searchMenu, Long schoolId,
@@ -64,6 +77,53 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
     return new PageImpl<>(storeList, pageable, count);
   }
 
+  @Override
+  public Page<SimpleInformation> getStorePageByEntrepreneur(
+      Entrepreneur entrepreneur, Pageable pageable, boolean unprocessedOnly) {
+    Long count = getStoresCountByEntrepreneur(entrepreneur, unprocessedOnly);
+
+    return new PageImpl<>(getStoreListByEntrepreneur(
+        entrepreneur, pageable, unprocessedOnly), pageable, count);
+  }
+
+  private List<SimpleInformation> getStoreListByEntrepreneur(
+      Entrepreneur entrepreneur, Pageable pageable, boolean unprocessedOnly) {
+    List<OrderSpecifier<?>> orderSpecifiers = getOrderSpecifiers(pageable.getSort());
+
+    return queryFactory
+        .select(new QStoreDto_SimpleInformation(
+            store.id,
+            store.name,
+            storeImage.url,
+            count(meeting.id)
+        ))
+        .from(store)
+        .leftJoin(storeImage).on(storeImage.store.eq(store).and(storeImage.isRepresentative.isTrue()))
+        .leftJoin(meeting).on(meeting.store.eq(store).and(meeting.status.eq(MeetingStatus.PURCHASE_COMPLETED)))
+        .groupBy(store.id)
+        .where(store.entrepreneur.eq(entrepreneur),
+            store.deletedAt.isNull())
+        .having(unprocessedOnly ? meeting.id.count().gt(0) : null)
+        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+  }
+
+  @Override
+  public Long getStoresCountByEntrepreneur(Entrepreneur entrepreneur, boolean unprocessedOnly) {
+    return queryFactory
+        .select(store.id.count())
+        .from(store)
+        .leftJoin(storeImage).on(storeImage.store.eq(store).and(storeImage.isRepresentative.isTrue()))
+        .leftJoin(meeting).on(meeting.store.eq(store).and(meeting.status.eq(MeetingStatus.PURCHASE_COMPLETED)))
+        .groupBy(store.id)
+        .where(store.entrepreneur.eq(entrepreneur),
+            store.deletedAt.isNull())
+        .having(unprocessedOnly ? meeting.id.count().gt(0) : null)
+        .fetchOne();
+  }
+
   private BooleanExpression[] where(List<Long> categoryList, String searchMenu) {
     List<BooleanExpression> list = new ArrayList<>();
 
@@ -88,6 +148,26 @@ public class CustomStoreRepositoryImpl implements CustomStoreRepository {
     }
 
     return list.toArray(new OrderSpecifier[0]);
+  }
+
+  private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort) {
+    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+    for (Order order : sort) {
+      OrderSpecifier<?> orderSpecifier = switch (order.getProperty()) {
+        case "name" -> order.isAscending() ?
+            store.name.asc() : store.name.desc();
+        case "storeId" -> order.isAscending() ?
+            store.id.asc() : store.id.desc();
+        case "createdAt" -> order.isAscending() ?
+            store.createdAt.asc() : store.createdAt.desc();
+        case "updatedAt" -> order.isAscending() ?
+            store.updatedAt.asc() : store.updatedAt.desc();
+        default -> throw new IllegalArgumentException("Unknown sort property: " + order.getProperty());
+      };
+      orderSpecifiers.add(orderSpecifier);
+    }
+    return orderSpecifiers;
   }
 
   private BooleanExpression filterCategory(List<Long> categoryList) {

--- a/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
@@ -1,7 +1,6 @@
 package com.zerobase.babdeusilbun.service;
 
 import com.zerobase.babdeusilbun.dto.CategoryDto;
-import com.zerobase.babdeusilbun.dto.CategoryDto.Information;
 import com.zerobase.babdeusilbun.dto.HolidayDto;
 import com.zerobase.babdeusilbun.dto.SchoolDto;
 import com.zerobase.babdeusilbun.dto.StoreDto;
@@ -15,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface StoreService {
   StoreDto.IdResponse createStore(Long entrepreneurId, CreateRequest request);
   int uploadImageToStore(Long entrepreneurId, List<MultipartFile> images, Long storeId);
-  Page<Information> getAllCategories(int page, int size);
+  Page<CategoryDto.Information> getAllCategories(int page, int size);
   int enrollToCategory(Long entrepreneurId, Long storeId, CategoryDto.IdsRequest request);
   int deleteOnCategory(Long entrepreneurId, Long storeId, CategoryDto.IdsRequest request);
   int enrollSchoolsToStore(Long entrepreneurId, Long storeId, SchoolDto.IdsRequest request);
@@ -25,7 +24,8 @@ public interface StoreService {
   boolean deleteImageOnStore(Long entrepreneurId, Long storeId, Long imageId);
   void updateStoreImage(Long entrepreneurId, Long storeId, Long imageId, StoreImageDto.UpdateRequest request);
   void updateStoreInformation(Long entrepreneurId, Long storeId, StoreDto.UpdateRequest request);
-
   Page<StoreDto.Information> getAvailStoreList
       (List<Long> categoryList, String searchMenu, Long schoolId, String sortCriteria, Pageable pageable);
+  void deleteStore(Long entrepreneurId, Long storeId);
+  Page<StoreDto.SimpleInformation> getAllStoresByEntrepreneur(Long entrepreneurId, int page, int size, boolean unprocessedOnly);
 }

--- a/src/test/java/com/zerobase/babdeusilbun/controller/StoreControllerTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/controller/StoreControllerTest.java
@@ -565,4 +565,39 @@ public class StoreControllerTest {
             .with(csrf()))
         .andExpect(status().isOk());
   }
+
+  @DisplayName("상점 삭제 컨트롤러 테스트(성공)")
+  @Test
+  void deleteStoreSuccess() throws Exception {
+    doNothing().when(storeService).deleteStore(eq(testEntrepreneur.getId()), eq(1L));
+
+    mockMvc.perform(delete("/api/businesses/stores/1")
+            .with(csrf()))
+        .andExpect(status().isNoContent());
+  }
+
+  @DisplayName("등록한 상점 리스트 조회 컨트롤러 테스트(성공)")
+  @Test
+  void getAllStoresByEntrepreneurSuccess() throws Exception {
+    List<StoreDto.SimpleInformation> storeList = List.of(
+        StoreDto.SimpleInformation.builder().storeId(1L).name("가나다 상점").build(),
+        StoreDto.SimpleInformation.builder().storeId(2L).name("나다라 상점").build()
+    );
+    Page<StoreDto.SimpleInformation> storePage = new PageImpl<>(storeList);
+
+    when(storeService.getAllStoresByEntrepreneur(
+        eq(testEntrepreneur.getId()), eq(0), eq(10), eq(false)))
+        .thenReturn(storePage);
+
+    mockMvc.perform(get("/api/businesses/stores")
+            .param("page", "0")
+            .param("size", "10")
+            .param("unprocessedOnly", "false")
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content.length()").value(2))
+        .andExpect(jsonPath("$.content[0].storeId").value(1L))
+        .andExpect(jsonPath("$.content[0].name").value("가나다 상점"));
+  }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 사업가가 본인이 등록한 상점 목록을 조회하는 기능이 없었습니다.
- 사업가가 본인이 등록한 상점을 삭제하는 기능이 없었습니다.
- 레포지토리에 어노테이션으로 명시를 하지 않았습니다.
- 서비스에 같은 레포지토리를 이름을 다르게 호출하고 있었습니다.

**TO-BE**
- 사업가가 본인이 등록한 상점 목록을 조회하는 기능을 구현했습니다.
  - unprocessedOnly에 true 전달 시 처리하지 않은 구매(주문)이 있는 상점만 조회되게 구현하였습니다.
  - 정렬은 상점 이름순입니다.
- 사업가가 본인이 등록한 상점을 삭제하는 기능을 구현했습니다.
- 레포지토리에 어노테이션으로 레포지토리임을 명시했습니다.
- 서비스에 중복되게 호출되는 레포지토리를 하나로 정리했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 사업가가 본인이 등록한 상점 목록을 조회하는 데에 성공한 컨트롤러 테스트를 구현하였습니다.
  - 사업가가 본인이 등록한 상점을 삭제하는 컨트롤러 테스트를 구현하였습니다.
  - 사업가가 본인이 등록한 상점 목록을 조회하는 서비스를 테스트하는 코드를 사례별로 구현하였습니다.
  - 사업가가 본인이 등록한 상점을 삭제하는 서비스를 테스트하는 코드를 사례별로 구현하였습니다.
- [x] API 테스트 