### PR TITLE
feature: 상점 관련 조회(이미지, 휴일, 카테고리, 사업자, 썸네일, 상점 정보, 캠퍼스) 기능 구현, 테스트, test: 구현 기능 테스트

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/StoreController.java
@@ -6,11 +6,15 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
 
 import com.zerobase.babdeusilbun.dto.CategoryDto;
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto;
 import com.zerobase.babdeusilbun.dto.HolidayDto;
+import com.zerobase.babdeusilbun.dto.MenuDto;
 import com.zerobase.babdeusilbun.dto.SchoolDto;
+import com.zerobase.babdeusilbun.dto.StoreCategoryDto;
 import com.zerobase.babdeusilbun.dto.StoreDto;
 import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
 import com.zerobase.babdeusilbun.dto.StoreImageDto;
+import com.zerobase.babdeusilbun.dto.StoreSchoolDto;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.StoreService;
 import java.util.List;
@@ -307,32 +311,82 @@ public class StoreController {
   /**
    * 상점 정보 조회
    */
+  @GetMapping("/stores/{storeId}")
+  public ResponseEntity<StoreDto.PrincipalInformation> getStoreInfo(
+      @PathVariable("storeId") Long storeId) {
+    return ResponseEntity.ok(storeService.getStore(storeId));
+  }
 
   /**
    * 상점별 휴무일 조회
    */
+  @GetMapping("/stores/{storeId}/holidays")
+  public ResponseEntity<Page<HolidayDto.Information>> getAllHolidays(
+      @PathVariable("storeId") Long storeId,
+      @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+      @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+    return ResponseEntity.ok(storeService.getAllHolidays(storeId, page, size));
+  }
 
   /**
    * 상점별 카테고리 조회
    */
+  @GetMapping("/stores/{storeId}/categories")
+  public ResponseEntity<Page<StoreCategoryDto.Information>> getAllCategories(
+      @PathVariable("storeId") Long storeId,
+      @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+      @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+    return ResponseEntity.ok(storeService.getAllCategories(storeId, page, size));
+  }
 
   /**
    * 가게별 메뉴 리스트 조회
    */
+  @GetMapping("/stores/{storeId}/menus")
+  public ResponseEntity<Page<MenuDto.Information>> getAllMenus(
+      @PathVariable("storeId") Long storeId,
+      @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+      @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+    return ResponseEntity.ok(storeService.getAllMenus(storeId, page, size));
+  }
 
   /**
    * 상점별 사업자 정보 조회
    */
+  @GetMapping("/stores/{storeId}/entrepreneur")
+  public ResponseEntity<EntrepreneurDto.SimpleInformation> getEntrepreneur(
+      @PathVariable("storeId") Long storeId) {
+    return ResponseEntity.ok(storeService.getEntrepreneur(storeId));
+  }
 
   /**
    * 상점별 배달가능 캠퍼스 조회
    */
+  @GetMapping("/stores/{storeId}/schools")
+  public ResponseEntity<Page<StoreSchoolDto.Information>> getAllSchools(
+      @PathVariable("storeId") Long storeId,
+      @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+      @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+    return ResponseEntity.ok(storeService.getAllSchools(storeId, page, size));
+  }
 
   /**
    * 상점 이미지 전체 조회
    */
+  @GetMapping("/stores/{storeId}/images")
+  public ResponseEntity<Page<StoreImageDto.Information>> getAllImages(
+      @PathVariable("storeId") Long storeId,
+      @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+      @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+    return ResponseEntity.ok(storeService.getAllImages(storeId, page, size));
+  }
 
   /**
    * 썸네일 조회
    */
+  @GetMapping("/stores/{storeId}/thumbnail")
+  public ResponseEntity<StoreImageDto.Thumbnail> getThumbnail(
+      @PathVariable("storeId") Long storeId) {
+    return ResponseEntity.ok(storeService.getThumbnail(storeId));
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/AddressDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/AddressDto.java
@@ -19,6 +19,9 @@ public class AddressDto {
   private String detailAddress;
 
   public static AddressDto fromEntity(Address address) {
+    if (address == null) return AddressDto.builder()
+        .build();
+
     return AddressDto.builder()
         .postal(address.getPostal())
         .streetAddress(address.getStreetAddress())

--- a/src/main/java/com/zerobase/babdeusilbun/dto/EntrepreneurDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/EntrepreneurDto.java
@@ -1,0 +1,23 @@
+package com.zerobase.babdeusilbun.dto;
+
+import com.zerobase.babdeusilbun.domain.Entrepreneur;
+import lombok.Builder;
+import lombok.Data;
+
+public class EntrepreneurDto {
+  @Data
+  @Builder
+  public static class SimpleInformation {
+    private String name;
+    private String businessNumber;
+    private String image;
+
+    public static SimpleInformation fromEntity(Entrepreneur entrepreneur) {
+      return SimpleInformation.builder()
+          .name(entrepreneur.getName())
+          .businessNumber(entrepreneur.getBusinessNumber())
+          .image(entrepreneur.getImage())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/dto/HolidayDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/HolidayDto.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 
 public class HolidayDto {
   @Data
@@ -15,5 +16,12 @@ public class HolidayDto {
   @EqualsAndHashCode
   public static class HolidaysRequest {
     private Set<DayOfWeek> holidays = new HashSet<>();
+  }
+
+  public interface Information {
+    @Value("#{target.id}")
+    Long getHolidayId();
+    @Value("#{T(com.zerobase.babdeusilbun.util.ConverterUtility).dayOfWeekConvert(target.dayOfWeek)}")
+    String getDayOfWeek();
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/MenuDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/MenuDto.java
@@ -5,6 +5,7 @@ import com.zerobase.babdeusilbun.domain.Store;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.*;
+import org.springframework.beans.factory.annotation.Value;
 
 public class MenuDto {
     @Data
@@ -55,5 +56,14 @@ public class MenuDto {
                     .price(price)
                     .build();
         }
+    }
+
+    public interface Information {
+        @Value("#{target.id}")
+        Long getMenuId();
+        String getName();
+        String getImage();
+        String getDescription();
+        Long getPrice();
     }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/SchoolDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/SchoolDto.java
@@ -1,5 +1,7 @@
 package com.zerobase.babdeusilbun.dto;
 
+import static com.zerobase.babdeusilbun.util.ConverterUtility.schoolNameConvert;
+
 import com.querydsl.core.annotations.QueryProjection;
 import com.zerobase.babdeusilbun.domain.School;
 import java.time.LocalDateTime;
@@ -42,7 +44,7 @@ public class SchoolDto {
     public static Information fromEntity(School school) {
       return Information.builder()
           .id(school.getId())
-          .name(school.getName().replaceAll("(\\s|\\()[^\\s]+((캠퍼스)|\\))$", ""))
+          .name(schoolNameConvert(school.getName()))
           .campus(school.getCampus())
           .build();
     }
@@ -50,7 +52,7 @@ public class SchoolDto {
     @QueryProjection
     public Information(Long id, String name, String campus) {
       this.id = id;
-      this.name = name.replaceAll("(\\s|\\()[^\\s]+((캠퍼스)|\\))$", "");
+      this.name = schoolNameConvert(name);
       this.campus = campus;
     }
   }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreCategoryDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreCategoryDto.java
@@ -1,0 +1,12 @@
+package com.zerobase.babdeusilbun.dto;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public class StoreCategoryDto {
+  public interface Information {
+    @Value("#{target.category.id}")
+    Long getCategoryId();
+    @Value("#{target.category.name}")
+    String getName();
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
@@ -14,7 +14,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
 
 public class StoreDto {
   @Data
@@ -149,6 +148,37 @@ public class StoreDto {
       this.name = name;
       this.image = image;
       this.unprocessedPurchaseCount = (unprocessedPurchaseCount == null) ? 0 : unprocessedPurchaseCount.intValue();
+    }
+  }
+
+  @Data
+  @Builder
+  public static class PrincipalInformation {
+    private Long storeId;
+    private Long entrepreneurId;
+    private String name;
+    private String description;
+    private Long minPurchasePrice;
+    private String deliveryTimeRange;
+    private Long deliveryPrice;
+    private AddressDto address;
+    private String phoneNumber;
+    private String openTime;
+    private String closeTime;
+
+    public static PrincipalInformation fromEntity(Store store) {
+      return PrincipalInformation.builder()
+          .storeId(store.getId())
+          .entrepreneurId(store.getEntrepreneur().getId())
+          .name(store.getName())
+          .description(store.getDescription())
+          .minPurchasePrice(store.getMinPurchaseAmount())
+          .deliveryTimeRange(store.getMinDeliveryTime() + "분 ~ " + store.getMaxDeliveryTime() + "분")
+          .deliveryPrice(store.getDeliveryPrice())
+          .address(AddressDto.fromEntity(store.getAddress()))
+          .openTime((store.getOpenTime() != null) ? store.getOpenTime().toString() : null)
+          .closeTime((store.getCloseTime() != null) ? store.getCloseTime().toString() : null)
+          .build();
     }
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreDto.java
@@ -169,7 +169,7 @@ public class StoreDto {
     public static PrincipalInformation fromEntity(Store store) {
       return PrincipalInformation.builder()
           .storeId(store.getId())
-          .entrepreneurId(store.getEntrepreneur().getId())
+          .entrepreneurId((store.getEntrepreneur() != null) ? store.getEntrepreneur().getId() : null)
           .name(store.getName())
           .description(store.getDescription())
           .minPurchasePrice(store.getMinPurchaseAmount())

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreImageDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreImageDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 
 @Getter
 @Builder
@@ -33,5 +34,19 @@ public class StoreImageDto {
     private Integer sequence;
     @JsonProperty("isRepresentative")
     private Boolean isRepresentative;
+  }
+
+  public interface Information {
+    @Value("#{target.id}")
+    Long getImageId();
+    String getUrl();
+    int getSequence();
+    boolean getIsRepresentative();
+  }
+
+  public interface Thumbnail {
+    @Value("#{target.id}")
+    Long getImageId();
+    String getUrl();
   }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreSchoolDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreSchoolDto.java
@@ -6,7 +6,7 @@ public class StoreSchoolDto {
   public interface Information {
     @Value("#{target.school.id}")
     Long getSchoolId();
-    @Value("#{target.school.name.replaceAll('(\\s|\\()[^\\s]+((캠퍼스)|\\))$', '', '')}")
+    @Value("#{T(com.zerobase.babdeusilbun.util.ConverterUtility).schoolNameConvert(target.school.name)}")
     String getName();
     @Value("#{target.school.campus}")
     String getCampus();

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreSchoolDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreSchoolDto.java
@@ -6,7 +6,7 @@ public class StoreSchoolDto {
   public interface Information {
     @Value("#{target.school.id}")
     Long getSchoolId();
-    @Value("#{target.school.name}")
+    @Value("#{target.school.name.replaceAll('(\\s|\\()[^\\s]+((캠퍼스)|\\))$', '', '')}")
     String getName();
     @Value("#{target.school.campus}")
     String getCampus();

--- a/src/main/java/com/zerobase/babdeusilbun/dto/StoreSchoolDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/StoreSchoolDto.java
@@ -1,0 +1,14 @@
+package com.zerobase.babdeusilbun.dto;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public class StoreSchoolDto {
+  public interface Information {
+    @Value("#{target.school.id}")
+    Long getSchoolId();
+    @Value("#{target.school.name}")
+    String getName();
+    @Value("#{target.school.campus}")
+    String getCampus();
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/repository/HolidayRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/HolidayRepository.java
@@ -2,9 +2,12 @@ package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Holiday;
 import com.zerobase.babdeusilbun.domain.Store;
+import com.zerobase.babdeusilbun.dto.HolidayDto;
 import java.time.DayOfWeek;
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +19,18 @@ public interface HolidayRepository extends JpaRepository<Holiday, Long> {
   List<DayOfWeek> findHolidaysByStore(@Param("store") Store store);
 
   int deleteByStoreAndDayOfWeekIn(Store store, Set<DayOfWeek> dayOfWeeks);
+
+  int countByStore(Store store);
+
+  @Query("SELECT h FROM Holiday h WHERE h.store = :store " +
+      "ORDER BY CASE h.dayOfWeek " +
+      "WHEN 'MONDAY' THEN 1 " +
+      "WHEN 'TUESDAY' THEN 2 " +
+      "WHEN 'WEDNESDAY' THEN 3 " +
+      "WHEN 'THURSDAY' THEN 4 " +
+      "WHEN 'FRIDAY' THEN 5 " +
+      "WHEN 'SATURDAY' THEN 6 " +
+      "WHEN 'SUNDAY' THEN 7 " +
+      "ELSE 8 END ASC")
+  Page<HolidayDto.Information> findByStoreOrderByDayOfWeek(@Param("store") Store store, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/MenuRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/MenuRepository.java
@@ -2,12 +2,16 @@ package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Menu;
 import com.zerobase.babdeusilbun.domain.Store;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import com.zerobase.babdeusilbun.dto.MenuDto.Information;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
     Optional<Menu> findByIdAndDeletedAtIsNull(Long menuId);
 
     boolean existsByStoreAndNameAndPriceAndDeletedAtIsNull(Store store, String name, long price);
+    int countByStoreAndDeletedAtIsNull(Store store);
+    Page<Information> findByStoreAndDeletedAtIsNull(Store store, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreCategoryRepository.java
@@ -2,12 +2,17 @@ package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.StoreCategory;
+import com.zerobase.babdeusilbun.dto.StoreCategoryDto;
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StoreCategoryRepository extends JpaRepository<StoreCategory, Long> {
   @Query("SELECT sc.category.id FROM StoreCategory sc WHERE sc.store = :store")
   List<Long> findCategoryIdsByStore(@Param("store") Store store);
@@ -15,4 +20,8 @@ public interface StoreCategoryRepository extends JpaRepository<StoreCategory, Lo
   int deleteByStoreAndCategory_IdIn(Store store, Set<Long> categoryIds);
 
   void deleteByStoreAndCategory_IdNotIn(Store store, Set<Long> categoryIds);
+
+  int countByStore(Store store);
+
+  Page<StoreCategoryDto.Information> findByStore(Store store, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreImageRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreImageRepository.java
@@ -2,14 +2,19 @@ package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.StoreImage;
+import com.zerobase.babdeusilbun.dto.StoreImageDto;
+import com.zerobase.babdeusilbun.dto.StoreImageDto.Thumbnail;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {
-
   List<StoreImage> findAllByStoreOrderBySequenceAsc(Store store);
   int countByStore(Store store);
-
+  Page<StoreImageDto.Information> findByStore(Store store, Pageable pageable);
+  Optional<Thumbnail> findFirstByStoreAndIsRepresentativeTrue(Store store);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/StoreSchoolRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/StoreSchoolRepository.java
@@ -2,8 +2,11 @@ package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Store;
 import com.zerobase.babdeusilbun.domain.StoreSchool;
+import com.zerobase.babdeusilbun.dto.StoreSchoolDto.Information;
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +20,7 @@ public interface StoreSchoolRepository extends JpaRepository<StoreSchool, Long> 
   int deleteByStoreAndSchool_IdIn(Store store, Set<Long> schoolIds);
 
   void deleteByStoreAndSchool_IdNotIn(Store store, Set<Long> schoolIds);
+
+  int countByStore(Store store);
+  Page<Information> findByStore(Store store, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/StoreService.java
@@ -1,11 +1,15 @@
 package com.zerobase.babdeusilbun.service;
 
 import com.zerobase.babdeusilbun.dto.CategoryDto;
+import com.zerobase.babdeusilbun.dto.EntrepreneurDto;
 import com.zerobase.babdeusilbun.dto.HolidayDto;
+import com.zerobase.babdeusilbun.dto.MenuDto;
 import com.zerobase.babdeusilbun.dto.SchoolDto;
+import com.zerobase.babdeusilbun.dto.StoreCategoryDto;
 import com.zerobase.babdeusilbun.dto.StoreDto;
 import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
 import com.zerobase.babdeusilbun.dto.StoreImageDto;
+import com.zerobase.babdeusilbun.dto.StoreSchoolDto;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,5 +31,14 @@ public interface StoreService {
   Page<StoreDto.Information> getAvailStoreList
       (List<Long> categoryList, String searchMenu, Long schoolId, String sortCriteria, Pageable pageable);
   void deleteStore(Long entrepreneurId, Long storeId);
-  Page<StoreDto.SimpleInformation> getAllStoresByEntrepreneur(Long entrepreneurId, int page, int size, boolean unprocessedOnly);
+  Page<StoreDto.SimpleInformation> getAllStoresByEntrepreneur(
+      Long entrepreneurId, int page, int size, boolean unprocessedOnly);
+  StoreDto.PrincipalInformation getStore(Long storeId);
+  Page<HolidayDto.Information> getAllHolidays(Long storeId, int page, int size);
+  Page<StoreCategoryDto.Information> getAllCategories(Long storeId, int page, int size);
+  Page<MenuDto.Information> getAllMenus(Long storeId, int page, int size);
+  EntrepreneurDto.SimpleInformation getEntrepreneur(Long storeId);
+  Page<StoreSchoolDto.Information> getAllSchools(Long storeId, int page, int size);
+  Page<StoreImageDto.Information> getAllImages(Long storeId, int page, int size);
+  StoreImageDto.Thumbnail getThumbnail(Long storeId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/util/ConverterUtility.java
+++ b/src/main/java/com/zerobase/babdeusilbun/util/ConverterUtility.java
@@ -1,0 +1,21 @@
+package com.zerobase.babdeusilbun.util;
+
+import java.time.DayOfWeek;
+
+public class ConverterUtility {
+  public static String dayOfWeekConvert(DayOfWeek dayOfWeek) {
+    if (dayOfWeek == null) {
+      throw new IllegalArgumentException("DayOfWeek cannot be null");
+    }
+
+    return switch (dayOfWeek) {
+      case MONDAY -> "월요일";
+      case TUESDAY -> "화요일";
+      case WEDNESDAY -> "수요일";
+      case THURSDAY -> "목요일";
+      case FRIDAY -> "금요일";
+      case SATURDAY -> "토요일";
+      case SUNDAY -> "일요일";
+    };
+  }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/util/ConverterUtility.java
+++ b/src/main/java/com/zerobase/babdeusilbun/util/ConverterUtility.java
@@ -18,4 +18,12 @@ public class ConverterUtility {
       case SUNDAY -> "일요일";
     };
   }
+
+  public static String schoolNameConvert(String name) {
+    if (name == null) {
+      return null;
+    }
+
+    return name.replaceAll("(\\s|\\()[^\\s]+((캠퍼스)|\\))$", "");
+  }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 상점 정보 조회 기능이 구현되지 않았습니다.
- 상점 휴무일 조회 기능이 구현되지 않았습니다.
- 상점 카테고리 조회 기능이 구현되지 않았습니다.
- 상점 사업자 조회 기능이 구현되지 않았습니다.
- 상점 썸네일 조회 기능이 구현되지 않았습니다.
- 상점 정보 조회 기능이 구현되지 않았습니다.
- 상점 배달가능 캠퍼스 조회 기능이 구현되지 않았습니다.

**TO-BE**
 - 각종 조회 기능을 구현하였습니다.
   - 상점 정보 조회 기능
     - 상점 기본 정보 관련해서는 deletedAt이 null이 아니어도 조회될 수 있게 했습니다! 상점이 삭제되어도 주문내역에서 확인했을 때 확인 가능하도록요.
   - 상점 휴무일 조회 기능
     - ConverterUtility를 생성하여 enum 값에 따라 출력되는 값이 지정되게 하였습니다.
     - 상점 휴무일 순서는 월요일부터 일요일까지 순차적으로 정렬되게 하였습니다.
   - 상점 카테고리 조회 기능
     - 상점 카테고리는 카테고리 이름 순서대로 정렬되게 하였습니다.
   - 상점 사업자 조회 기능
   - 상점 썸네일 조회 기능
   - 상점 정보 조회 기능
   - 상점 배달가능 캠퍼스 조회 기능
 - response DTO는 가능한 인터페이스로 생성하여 레포지토리에서 바로 매핑될 수 있도록 하고, 서비스단에선 pageable 객체를 만드는 것으로 조절했습니다.
 - DTO를 인터페이스로 생성하는 것과 정적 클래스로 만드는 것은 장단점이 명확했습니다. 이후 리팩토링을 진행할 때 어떻게 할 지 통일하면 좋을 것 같습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 각 컨트롤러 테스트코드를 통해 서비스와 잘 연결되었는지, 원하는 형태로 값이 나오는지 확인했습니다.
  - 각 사례별로 서비스 테스트를 진행할 수 있도록 하였습니다.
- [x] API 테스트 