### PR TITLE
refactor: 문의 조회 리스트, 상세조회 합침, 스냅샷 내림차순

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/InquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/InquiryController.java
@@ -3,8 +3,7 @@ package com.zerobase.babdeusilbun.controller;
 import static org.springframework.http.HttpStatus.*;
 
 import com.zerobase.babdeusilbun.dto.InquiryDto;
-import com.zerobase.babdeusilbun.dto.InquiryDto.DetailResponse;
-import com.zerobase.babdeusilbun.dto.InquiryDto.ListResponse;
+import com.zerobase.babdeusilbun.dto.InquiryDto.Response;
 import com.zerobase.babdeusilbun.dto.InquiryImageDto;
 import com.zerobase.babdeusilbun.service.InquiryService;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
@@ -36,22 +35,13 @@ public class InquiryController {
 
   // 문의 게시물 목록 조회
   @GetMapping
-  public ResponseEntity<Page<ListResponse>> getInquiryList(
-      @RequestParam String statusFilter, Pageable pageable
+  public ResponseEntity<Page<Response>> getInquiryList(
+      @AuthenticationPrincipal CustomUserDetails userDetails, Pageable pageable
   ) {
 
     return ResponseEntity.ok(
-        inquiryService.getInquiryList(statusFilter, pageable)
-            .map(InquiryDto.ListResponse::fromEntity)
-    );
-  }
-
-  // 문의 게시물 상세 조회
-  @GetMapping("/{inquiryId}")
-  public ResponseEntity<InquiryDto.DetailResponse> getInquiryInfo(@PathVariable Long inquiryId) {
-
-    return ResponseEntity.ok(
-        DetailResponse.fromEntity(inquiryService.getInquiryInfo(inquiryId))
+        inquiryService.getInquiryList(userDetails.getId(), pageable)
+            .map(InquiryDto.Response::fromEntity)
     );
   }
 
@@ -70,12 +60,13 @@ public class InquiryController {
 
   // 문의 이미지 전체 조회
   @GetMapping("/{inquiryId}/images")
-  public ResponseEntity<Page<InquiryImageDto>> getInquiryImages
-  (@PathVariable Long inquiryId, Pageable pageable) {
+  public ResponseEntity<List<InquiryImageDto>> getInquiryImages
+  (@PathVariable Long inquiryId) {
 
     return ResponseEntity.ok(
-        inquiryService.getInquiryImageList(inquiryId, pageable)
-            .map(InquiryImageDto::fromEntity)
+        inquiryService.getInquiryImageList(inquiryId)
+            .stream().map(InquiryImageDto::fromEntity)
+            .toList()
     );
   }
 

--- a/src/main/java/com/zerobase/babdeusilbun/dto/EntrepreneurDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/EntrepreneurDto.java
@@ -24,7 +24,6 @@ public class EntrepreneurDto {
     }
   }
 
-public class EntrepreneurDto {
     @Data
     @Builder
     @AllArgsConstructor

--- a/src/main/java/com/zerobase/babdeusilbun/dto/InquiryDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/InquiryDto.java
@@ -29,34 +29,7 @@ public class InquiryDto {
   @AllArgsConstructor
   @NoArgsConstructor(access = AccessLevel.PROTECTED)
   @Builder
-  public static class ListResponse {
-
-    private Long inquiryId;
-
-    private String title;
-
-    private InquiryStatus status;
-
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-
-    public static InquiryDto.ListResponse fromEntity(Inquiry inquiry) {
-      return ListResponse.builder()
-          .inquiryId(inquiry.getId())
-          .title(inquiry.getTitle())
-          .status(inquiry.getStatus())
-          .createdAt(inquiry.getCreatedAt())
-          .updatedAt(inquiry.getUpdatedAt())
-          .build();
-    }
-
-  }
-
-  @Getter
-  @AllArgsConstructor
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
-  @Builder
-  public static class DetailResponse {
+  public static class Response {
 
     private Long inquiryId;
 
@@ -69,8 +42,8 @@ public class InquiryDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static InquiryDto.DetailResponse fromEntity(Inquiry inquiry) {
-      return DetailResponse.builder()
+    public static InquiryDto.Response fromEntity(Inquiry inquiry) {
+      return Response.builder()
           .inquiryId(inquiry.getId())
           .title(inquiry.getTitle())
           .content(inquiry.getContent())
@@ -79,7 +52,5 @@ public class InquiryDto {
           .updatedAt(inquiry.getUpdatedAt())
           .build();
     }
-
   }
-
 }

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -87,6 +87,7 @@ public enum ErrorCode {
   // 문의 관련
   INQUIRY_NOT_FOUND(NOT_FOUND, "couldn't find inquiry"),
   INQUIRY_WRITER_NOT_MATCH(BAD_REQUEST, "this user is not writer of that inquiry"),
+  INQUIRY_ALREADY_COMPLETE(BAD_REQUEST, "this inquiry is already complete"),
 
   INQUIRY_IMAGE_NOT_FOUND(NOT_FOUND, "couldn't find inquiry image"),
   INQUIRY_IMAGE_SEQUENCE_INVALID(BAD_REQUEST, "inquiry image sequence is invalid"),

--- a/src/main/java/com/zerobase/babdeusilbun/repository/IndividualPurchasePaymentRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/IndividualPurchasePaymentRepository.java
@@ -15,7 +15,8 @@ public interface IndividualPurchasePaymentRepository extends JpaRepository<Indiv
       + "join IndividualPurchase ip on ipp.individualPurchase = ip "
       + "join Purchase p on ip.purchase = p "
       + "join Meeting m on p.meeting = m "
-      + "where p.user = :participant and m = :meeting ")
+      + "where p.user = :participant and m = :meeting "
+      + "order by ipp.createdAt desc ")
   Page<IndividualPurchasePayment> findAllByUserAndMeeting
       (User participant, Meeting meeting, Pageable pageable);
 

--- a/src/main/java/com/zerobase/babdeusilbun/repository/InquiryImageRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/InquiryImageRepository.java
@@ -10,8 +10,6 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface InquiryImageRepository extends JpaRepository<InquiryImage, Long> {
 
-  Page<InquiryImage> findAllByInquiryOrderBySequence(Inquiry inquiry, Pageable pageable);
-
   List<InquiryImage> findAllByInquiryOrderBySequence(Inquiry inquiry);
 
   @Query("select ii from InquiryImage ii "

--- a/src/main/java/com/zerobase/babdeusilbun/repository/InquiryRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/InquiryRepository.java
@@ -1,8 +1,13 @@
 package com.zerobase.babdeusilbun.repository;
 
 import com.zerobase.babdeusilbun.domain.Inquiry;
+import com.zerobase.babdeusilbun.domain.User;
 import com.zerobase.babdeusilbun.repository.custom.CustomInquiryRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long>, CustomInquiryRepository {
+
+  Page<Inquiry> findAllByUserOrderByCreatedAtDesc(User user, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/PaymentRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/PaymentRepository.java
@@ -12,6 +12,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
   @Query("select pm from Payment pm "
       + "join Purchase p on pm.purchase = p "
       + "join Meeting m on p.meeting = m "
-      + "where m = :meeting and p.user = :participant ")
+      + "where m = :meeting and p.user = :participant "
+      + "order by pm.createdAt desc ")
   Optional<Payment> findByMeetingAndUser(Meeting meeting, User participant);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/PurchasePaymentRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/PurchasePaymentRepository.java
@@ -14,7 +14,8 @@ public interface PurchasePaymentRepository extends JpaRepository<PurchasePayment
   @Query("select pp from PurchasePayment pp "
       + "join Purchase p on pp.purchase = p "
       + "join Meeting m on p.meeting = m "
-      + "where p.user = :participant and m = :meeting")
+      + "where p.user = :participant and m = :meeting "
+      + "order by pp.createdAt desc ")
   Optional<PurchasePayment> findByMeetingAndUser(Meeting meeting, User participant);
 
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/TeamPurchasePaymentRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/TeamPurchasePaymentRepository.java
@@ -9,10 +9,11 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface TeamPurchasePaymentRepository extends JpaRepository<TeamPurchasePayment, Long> {
 
-  @Query("select tp "
+  @Query("select tpp "
       + "from TeamPurchasePayment tpp "
       + "join TeamPurchase tp on tpp.teamPurchase = tp "
-      + "where tp.meeting = :meeting")
+      + "where tp.meeting = :meeting "
+      + "order by tpp.createdAt desc ")
   Page<TeamPurchasePayment> findByMeeting(Meeting meeting, Pageable pageable);
 
 

--- a/src/main/java/com/zerobase/babdeusilbun/service/InquiryService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/InquiryService.java
@@ -11,13 +11,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface InquiryService {
 
-  Page<Inquiry> getInquiryList(String statusFilter, Pageable pageable);
-
-  Inquiry getInquiryInfo(Long inquiryId);
+  Page<Inquiry> getInquiryList(Long userId, Pageable pageable);
 
   void createInquiry(CustomUserDetails userDetails, Request request, List<MultipartFile> images);
 
-  Page<InquiryImage> getInquiryImageList(Long inquiryId, Pageable pageable);
+  List<InquiryImage> getInquiryImageList(Long inquiryId);
 
   void updateImageSequence(CustomUserDetails userDetails, Long inquiryId, Long imageId, Integer updatedSequence);
 

--- a/src/test/java/com/zerobase/babdeusilbun/service/InquiryServiceTest.java
+++ b/src/test/java/com/zerobase/babdeusilbun/service/InquiryServiceTest.java
@@ -63,10 +63,11 @@ class InquiryServiceTest {
 
     Page<Inquiry> list = new PageImpl<>(List.of(pending));
 
-    when(inquiryRepository.findInquiryList(anyString(), any())).thenReturn(list);
+    when(inquiryRepository.findAllByUserOrderByCreatedAtDesc(user, pageable)).thenReturn(list);
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
     // when
-    Page<Inquiry> inquiryList = inquiryService.getInquiryList("", pageable);
+    Page<Inquiry> inquiryList = inquiryService.getInquiryList(1L, pageable);
     List<Inquiry> content = inquiryList.getContent();
 
     // then
@@ -76,31 +77,6 @@ class InquiryServiceTest {
     assertThat(content.size()).isEqualTo(1);
     assertThat(content.getFirst().getTitle()).isEqualTo("title1");
     assertThat(content.getFirst().getStatus()).isEqualTo(InquiryStatus.PENDING);
-  }
-
-  @Test
-  @DisplayName("문의 정보 조회")
-  void getInquiryInfo() throws Exception {
-    // given
-    User user = User.builder().id(1L).build();
-    Inquiry pending = Inquiry.builder()
-        .id(1L)
-        .user(user).title("title1").content("content1")
-        .status(InquiryStatus.PENDING).build();
-
-    when(inquiryRepository.findById(anyLong())).thenReturn(Optional.of(pending));
-
-    // when
-    Inquiry inquiryInfo = inquiryService.getInquiryInfo(1L);
-
-    // then
-    assertThat(inquiryInfo.getId()).isEqualTo(1L);
-    assertThat(inquiryInfo.getTitle()).isEqualTo(pending.getTitle());
-    assertThat(inquiryInfo.getAnswer()).isEqualTo(pending.getAnswer());
-    assertThat(inquiryInfo.getContent()).isEqualTo(pending.getContent());
-    assertThat(inquiryInfo.getStatus()).isEqualTo(pending.getStatus());
-    assertThat(inquiryInfo.getCreatedAt()).isEqualTo(pending.getCreatedAt());
-    assertThat(inquiryInfo.getUpdatedAt()).isEqualTo(pending.getUpdatedAt());
   }
 
   @Test
@@ -139,28 +115,19 @@ class InquiryServiceTest {
 
     List list = List.of(image1, image2, image3);
 
-    Pageable pageable = PageRequest.of(0, 3);
-
-    Page<InquiryImage> page = new PageImpl<>(list, pageable, 3);
-
     when(inquiryRepository.findById(anyLong())).thenReturn(Optional.of(inquiry));
-    when(inquiryImageRepository.findAllByInquiryOrderBySequence(inquiry, pageable)).thenReturn(
-        page);
+    when(inquiryImageRepository.findAllByInquiryOrderBySequence(inquiry)).thenReturn(list);
 
     // when
-    Page<InquiryImage> inquiryImageList = inquiryService.getInquiryImageList(1L, pageable);
-    List<InquiryImage> content = inquiryImageList.getContent();
+    List<InquiryImage> result = inquiryService.getInquiryImageList(1L);
 
     // then
     verify(inquiryRepository, times(1)).findById(1L);
-    verify(inquiryImageRepository, times(1)).findAllByInquiryOrderBySequence(inquiry, pageable);
-    assertThat(inquiryImageList.getTotalElements()).isEqualTo(3);
-    assertThat(inquiryImageList.getSize()).isEqualTo(3);
-    assertThat(inquiryImageList.getNumber()).isEqualTo(0);
-    assertThat(content.size()).isEqualTo(3);
-    assertThat(content.getFirst().getUrl()).isEqualTo(image1.getUrl());
-    assertThat(content.get(2).getUrl()).isEqualTo(image2.getUrl());
-    assertThat(content.getLast().getUrl()).isEqualTo(image3.getUrl());
+    verify(inquiryImageRepository, times(1)).findAllByInquiryOrderBySequence(inquiry);
+    assertThat(result.size()).isEqualTo(3);
+    assertThat(result.getFirst().getUrl()).isEqualTo(image1.getUrl());
+    assertThat(result.get(2).getUrl()).isEqualTo(image2.getUrl());
+    assertThat(result.getLast().getUrl()).isEqualTo(image3.getUrl());
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
문의글 조회와 상세조회가 나뉘어져 있어 불필요한 쿼리문이 호출되었습니다.
스냅샷이 생성일 오름차순으로 정렬되어 반환되었습니다.

**TO-BE**
문의글의 리스트를 반환할 때 상세정보도 같이 포함하여 반환되도록 하였습니다.
문의글의 상태 필터를 제거하였습니다.
불필요한 문의글 이미지 조회의 페이징 처리를 제거하였습니다.
스냅샷을 생성일 내림차순으로 반환되게 하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [ ] API 테스트 