### PR TITLE
feat : 공동주문(팀주문) 생성, 수정, 삭제 기능 추가 ( + EntrepreneurDto 분리 현상 수정 )

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/controller/IndividualPurchaseController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/IndividualPurchaseController.java
@@ -33,4 +33,31 @@ public class IndividualPurchaseController {
         return ResponseEntity.status(CREATED).build();
     }
 
+    /*
+     * 개별주문 장바구니 수정
+     * */
+    @PreAuthorize("hasRole('USER')")
+    @PatchMapping("/users/individual-purchases/{purchaseId}")
+    public ResponseEntity<Void> updateIndividualPurchase(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long purchaseId,
+            @Validated @RequestBody IndividualPurchaseDto.UpdateRequest request) {
+
+        individualPurchaseService.updateIndividualPurchase(userDetails.getId(), purchaseId, request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    /*
+     * 개별주문 장바구니 삭제
+     * */
+    @PreAuthorize("hasRole('USER')")
+    @DeleteMapping("/users/individual-purchases/{purchaseId}")
+    public ResponseEntity<Void> updateIndividualPurchase(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long purchaseId) {
+        individualPurchaseService.deleteIndividualPurchase(userDetails.getId(), purchaseId);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/controller/TeamPurchaseController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/TeamPurchaseController.java
@@ -1,0 +1,63 @@
+package com.zerobase.babdeusilbun.controller;
+
+import com.zerobase.babdeusilbun.dto.TeamPurchaseDto;
+import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
+import com.zerobase.babdeusilbun.service.TeamPurchaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class TeamPurchaseController {
+
+    private final TeamPurchaseService teamPurchaseService;
+
+    /*
+     * 공통주문 장바구니 등록
+     * */
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping("/users/meetings/{meetingId}/team-purchases")
+    public ResponseEntity<Void> createIndividualPurchase(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long meetingId,
+            @Validated @RequestBody TeamPurchaseDto.CreateRequest request) {
+        teamPurchaseService.createIndividualPurchase(userDetails.getId(), meetingId, request);
+
+        return ResponseEntity.status(CREATED).build();
+    }
+
+    /*
+     * 공통주문 장바구니 수정
+     * */
+    @PreAuthorize("hasRole('USER')")
+    @PatchMapping("/users/team-purchases/{purchaseId}")
+    public ResponseEntity<Void> updateIndividualPurchase(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long purchaseId,
+            @Validated @RequestBody TeamPurchaseDto.UpdateRequest request) {
+
+        teamPurchaseService.updateIndividualPurchase(userDetails.getId(), purchaseId, request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    /*
+     * 개별주문 장바구니 삭제
+     * */
+    @PreAuthorize("hasRole('USER')")
+    @DeleteMapping("/users/team-purchases/{purchaseId}")
+    public ResponseEntity<Void> updateIndividualPurchase(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long purchaseId) {
+        teamPurchaseService.deleteIndividualPurchase(userDetails.getId(), purchaseId);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/domain/IndividualPurchase.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/IndividualPurchase.java
@@ -42,4 +42,8 @@ public class IndividualPurchase extends BaseEntity{
   @Column(nullable = false)
   private Integer quantity;
 
+  public void updateQuantity(Integer quantity) {
+    if(quantity != null) this.quantity = quantity;
+  }
+
 }

--- a/src/main/java/com/zerobase/babdeusilbun/domain/TeamPurchase.java
+++ b/src/main/java/com/zerobase/babdeusilbun/domain/TeamPurchase.java
@@ -42,4 +42,7 @@ public class TeamPurchase extends BaseEntity{
   @Column(nullable = false)
   private Integer quantity;
 
+  public void updateQuantity(Integer quantity) {
+    if(quantity != null) this.quantity = quantity;
+  }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/EntrepreneurDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/EntrepreneurDto.java
@@ -8,23 +8,22 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 public class EntrepreneurDto {
-  @Data
-  @Builder
-  public static class SimpleInformation {
-    private String name;
-    private String businessNumber;
-    private String image;
+    @Data
+    @Builder
+    public static class SimpleInformation {
+        private String name;
+        private String businessNumber;
+        private String image;
 
-    public static SimpleInformation fromEntity(Entrepreneur entrepreneur) {
-      return SimpleInformation.builder()
-          .name(entrepreneur.getName())
-          .businessNumber(entrepreneur.getBusinessNumber())
-          .image(entrepreneur.getImage())
-          .build();
+        public static SimpleInformation fromEntity(Entrepreneur entrepreneur) {
+            return SimpleInformation.builder()
+                    .name(entrepreneur.getName())
+                    .businessNumber(entrepreneur.getBusinessNumber())
+                    .image(entrepreneur.getImage())
+                    .build();
+        }
     }
-  }
 
-public class EntrepreneurDto {
     @Data
     @Builder
     @AllArgsConstructor

--- a/src/main/java/com/zerobase/babdeusilbun/dto/IndividualPurchaseDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/IndividualPurchaseDto.java
@@ -18,4 +18,14 @@ public class IndividualPurchaseDto {
         @Positive(message = "quantity는 1이상의 정수 값이 들어와야 합니다.")
         private Integer quantity;
     }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
+    public static class UpdateRequest {
+        @Positive(message = "quantity는 1이상의 정수 값이 들어와야 합니다.")
+        private Integer quantity;
+    }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/dto/TeamPurchaseDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/TeamPurchaseDto.java
@@ -1,0 +1,30 @@
+package com.zerobase.babdeusilbun.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.*;
+
+public class TeamPurchaseDto {
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
+    public static class CreateRequest {
+        @NotNull(message = "menuId는 정수 값이 들어와야 합니다.")
+        private Long menuId;
+
+        @Positive(message = "quantity는 1이상의 정수 값이 들어와야 합니다.")
+        private Integer quantity;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
+    public static class UpdateRequest {
+        @Positive(message = "quantity는 1이상의 정수 값이 들어와야 합니다.")
+        private Integer quantity;
+    }
+}

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -67,6 +67,7 @@ public enum ErrorCode {
   PURCHASE_NOT_FOUND(NOT_FOUND, "couldn't find purchase"),
   PURCHASE_STATUS_INVALID(BAD_REQUEST, "purchase status is invalid"),
   PURCHASE_STATUS_CANCEL(NOT_FOUND, "this participant cancel that purchase"),
+  NO_AUTH_ON_PURCHASE(FORBIDDEN, "no auth to use or modify or delete this purchase"),
 
   // 개별 주문 관련
   ALREADY_EXIST_INDIVIDUAL_PURCHASE(CONFLICT, "already have individual_purchase which user want to enroll."),

--- a/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/babdeusilbun/exception/ErrorCode.java
@@ -69,6 +69,9 @@ public enum ErrorCode {
   PURCHASE_STATUS_CANCEL(NOT_FOUND, "this participant cancel that purchase"),
   NO_AUTH_ON_PURCHASE(FORBIDDEN, "no auth to use or modify or delete this purchase"),
 
+  // 팀 주문 관련
+  ALREADY_EXIST_TEAM_PURCHASE(CONFLICT, "already have team_purchase which user want to enroll."),
+
   // 개별 주문 관련
   ALREADY_EXIST_INDIVIDUAL_PURCHASE(CONFLICT, "already have individual_purchase which user want to enroll."),
 

--- a/src/main/java/com/zerobase/babdeusilbun/repository/IndividualPurchaseRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/IndividualPurchaseRepository.java
@@ -8,10 +8,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface IndividualPurchaseRepository extends JpaRepository<IndividualPurchase, Long> {
 
   @EntityGraph(attributePaths = {"purchase", "menu"})
   Page<IndividualPurchase> findAllByPurchase(Purchase purchase, Pageable pageable);
 
   boolean existsAllByMenuAndPurchase(Menu menu, Purchase purchase);
+
+  Optional<IndividualPurchase> findAllById(Long indiviualPurchaseId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/repository/TeamPurchaseRepository.java
+++ b/src/main/java/com/zerobase/babdeusilbun/repository/TeamPurchaseRepository.java
@@ -1,9 +1,7 @@
 package com.zerobase.babdeusilbun.repository;
 
-import com.zerobase.babdeusilbun.domain.Meeting;
-import com.zerobase.babdeusilbun.domain.Purchase;
-import com.zerobase.babdeusilbun.domain.TeamPurchase;
-import com.zerobase.babdeusilbun.domain.User;
+import com.zerobase.babdeusilbun.domain.*;
+
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -18,4 +16,7 @@ public interface TeamPurchaseRepository extends JpaRepository<TeamPurchase, Long
 
   Long countByMeeting(Meeting meeting);
 
+  boolean existsAllByMenuAndMeeting(Menu menu, Meeting meeting);
+
+  Optional<TeamPurchase> findAllById(Long teamPurchaseId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/IndividualPurchaseService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/IndividualPurchaseService.java
@@ -1,8 +1,13 @@
 package com.zerobase.babdeusilbun.service;
 
 import com.zerobase.babdeusilbun.dto.IndividualPurchaseDto.CreateRequest;
+import com.zerobase.babdeusilbun.dto.IndividualPurchaseDto.UpdateRequest;
 import com.zerobase.babdeusilbun.domain.IndividualPurchase;
 
 public interface IndividualPurchaseService {
     IndividualPurchase createIndividualPurchase(Long userId, Long meetingId, CreateRequest request);
+
+    IndividualPurchase updateIndividualPurchase(Long userId, Long purchaseId, UpdateRequest request);
+
+    void deleteIndividualPurchase(Long userId, Long purchaseId);
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/TeamPurchaseService.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/TeamPurchaseService.java
@@ -1,0 +1,13 @@
+package com.zerobase.babdeusilbun.service;
+
+import com.zerobase.babdeusilbun.domain.TeamPurchase;
+import com.zerobase.babdeusilbun.dto.TeamPurchaseDto.CreateRequest;
+import com.zerobase.babdeusilbun.dto.TeamPurchaseDto.UpdateRequest;
+
+public interface TeamPurchaseService {
+    TeamPurchase createIndividualPurchase(Long userId, Long meetingId, CreateRequest request);
+
+    TeamPurchase updateIndividualPurchase(Long userId, Long purchaseId, UpdateRequest request);
+
+    void deleteIndividualPurchase(Long userId, Long purchaseId);
+}

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/TeamPurchaseServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/TeamPurchaseServiceImpl.java
@@ -1,0 +1,122 @@
+package com.zerobase.babdeusilbun.service.impl;
+
+import com.zerobase.babdeusilbun.domain.*;
+import com.zerobase.babdeusilbun.dto.TeamPurchaseDto;
+import com.zerobase.babdeusilbun.enums.MeetingStatus;
+import com.zerobase.babdeusilbun.enums.PurchaseStatus;
+import com.zerobase.babdeusilbun.exception.CustomException;
+import com.zerobase.babdeusilbun.repository.*;
+import com.zerobase.babdeusilbun.service.TeamPurchaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TeamPurchaseServiceImpl implements TeamPurchaseService {
+    private final UserRepository userRepository;
+    private final MeetingRepository meetingRepository;
+    private final PurchaseRepository purchaseRepository;
+    private final MenuRepository menuRepository;
+    private final TeamPurchaseRepository teamPurchaseRepository;
+
+    @Override
+    public TeamPurchase createIndividualPurchase(Long userId, Long meetingId, TeamPurchaseDto.CreateRequest request) {
+        // 사용자 정보 찾기, 없으면 예외처리
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // 미팅 정보 찾기, 없으면 예외처리
+        Meeting meeting = meetingRepository.findAllByIdAndDeletedAtIsNull(meetingId)
+                .orElseThrow(() -> new CustomException(MEETING_NOT_FOUND));
+
+        // 메뉴 정보 찾기, 없으면 예외처리
+        Menu menu = menuRepository.findByIdAndDeletedAtIsNull(request.getMenuId())
+                .orElseThrow(() -> new CustomException(MENU_NOT_FOUND));
+
+        // 1. 현재 미팅의 리더인지 확인, 아니면 예외 처리
+        if(meeting.getLeader().getId() != userId) {
+            throw new CustomException(MEETING_LEADER_NOT_MATCH);
+        }
+
+        // 2. 현재 입력한 메뉴가 속한 매장 식별번호가 미팅 속 매장의 식별번호와 동일한지 확인, 아니면 예외 처리
+        if(menu.getStore().getId() != meeting.getStore().getId()) {
+            throw new CustomException(STORE_NOT_INCLUDE_MENU);
+        }
+
+        // 3. 모집중인 미팅인지 확인, 아니면 예외 처리
+        if(meeting.getStatus() != MeetingStatus.GATHERING) {
+            throw new CustomException(MEETING_STATUS_INVALID);
+        }
+
+        // 4. 현재 유저가 현재 미팅에 등록했던 팀 주문 중에서 이미 같은 음식을 등록했는지 확인, 아니면 예외처리
+        if(teamPurchaseRepository.existsAllByMenuAndMeeting(menu, meeting)) {
+            throw new CustomException(ALREADY_EXIST_TEAM_PURCHASE);
+        }
+
+        // 팀주문 새로 등록
+        TeamPurchase teamPurchase = TeamPurchase.
+                builder().
+                meeting(meeting).
+                menu(menu).
+                quantity(request.getQuantity()).
+                build();
+
+        teamPurchaseRepository.save(teamPurchase);
+
+        return teamPurchase;
+    }
+
+    @Override
+    @Transactional
+    public TeamPurchase updateIndividualPurchase(Long userId, Long purchaseId, TeamPurchaseDto.UpdateRequest request) {
+        // 사용자 정보 찾기, 없으면 예외처리
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // 팀구매 정보 찾기, 없으면 예외처리
+        TeamPurchase teamPurchase = teamPurchaseRepository.findAllById(purchaseId)
+                .orElseThrow(() -> new CustomException(PURCHASE_NOT_FOUND));
+
+        // 1. 현재 미팅의 리더인지 확인, 아니면 예외 처리
+        if(teamPurchase.getMeeting().getLeader().getId() != user.getId()) {
+            throw new CustomException(MEETING_LEADER_NOT_MATCH);
+        }
+
+        // 2. 모집중인 미팅인지 확인, 아니면 예외 처리
+        if(teamPurchase.getMeeting().getStatus() != MeetingStatus.GATHERING) {
+            throw new CustomException(MEETING_STATUS_INVALID);
+        }
+
+        // 개인구매 수량 정보 갱신
+        teamPurchase.updateQuantity(request.getQuantity());
+
+        return teamPurchase;
+    }
+
+    @Override
+    public void deleteIndividualPurchase(Long userId, Long purchaseId) {
+        // 사용자 정보 찾기, 없으면 예외처리
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // 팀구매 정보 찾기, 없으면 예외처리
+        TeamPurchase teamPurchase = teamPurchaseRepository.findAllById(purchaseId)
+                .orElseThrow(() -> new CustomException(PURCHASE_NOT_FOUND));
+
+        // 1. 현재 미팅의 리더인지 확인, 아니면 예외 처리
+        if(teamPurchase.getMeeting().getLeader().getId() != user.getId()) {
+            throw new CustomException(MEETING_LEADER_NOT_MATCH);
+        }
+
+        // 2. 모집중인 미팅인지 확인, 아니면 예외 처리
+        if(teamPurchase.getMeeting().getStatus() != MeetingStatus.GATHERING) {
+            throw new CustomException(MEETING_STATUS_INVALID);
+        }
+
+        teamPurchaseRepository.delete(teamPurchase);
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 원하는 모임에 공동 장바구니를 등록, 수정, 삭제 기능이 필요했습니다.

- EntreperneurDto 클래스가 두개로 분리되어 있었습니다.

**TO-BE**

- EntreperneurDto 클래스를 다시 1개로 합쳤습니다.

- 필요한 ErrorCode를 새로 생성하였습니다.

- 원하는 모임의 공동 장바구니(= 팀 장바구니)를 생성, 수정하거나 삭제하는 기능을 구현하였습니다.

- 각 기능의 작동순서를 TeamPurchaseServiceImpl.java에 주석으로 남겨놓았습니다.

- 고유번호를 기반으로 개별주문을 조회하는 메서드를 TeamPurchaseRepository.java에 추가하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 