### PR TITLE
feat : 긍정(부정)평가배지 배열에 특정 배지 정보가 없을 경우 count가 0인 상태로 배지 정보를 추가해주는 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/dto/EvaluateDto.java
+++ b/src/main/java/com/zerobase/babdeusilbun/dto/EvaluateDto.java
@@ -5,6 +5,8 @@ import lombok.*;
 
 import java.util.List;
 
+import static com.zerobase.babdeusilbun.enums.EvaluateBadge.*;
+
 public class EvaluateDto {
 
     @Data
@@ -32,5 +34,133 @@ public class EvaluateDto {
         Long getCount();
     }
 
+    public static void insertZeroValueInPositiveEvaluateArray(List<EvaluateDto.PositiveEvaluate> positiveEvaluateList) {
+        boolean isInGOOD_COMMUNICATION = false;
+        boolean isInGOOD_TIMECHECK = false;
+        boolean isInGOOD_TOGETHER = false;
+        boolean isInGOOD_RESPONSE = false;
 
+        for(int i = 0; i < positiveEvaluateList.size(); i++) {
+            switch(positiveEvaluateList.get(i).getContent()) {
+                case GOOD_COMMUNICATION :
+                    isInGOOD_COMMUNICATION = true;
+                    break;
+                case GOOD_TIMECHECK :
+                    isInGOOD_TIMECHECK = true;
+                    break;
+                case GOOD_TOGETHER :
+                    isInGOOD_TOGETHER = true;
+                    break;
+                case GOOD_RESPONSE :
+                    isInGOOD_RESPONSE = true;
+                    break;
+            }
+        }
+
+        if(!isInGOOD_COMMUNICATION) {
+            positiveEvaluateList.add(new EvaluateDto.PositiveEvaluate() {
+                @Override
+                public EvaluateBadge getContent() {
+                    return GOOD_COMMUNICATION;
+                }
+                @Override
+                public Long getCount() {
+                    return 0L;
+                }
+            });
+        }
+        if(!isInGOOD_TIMECHECK) {
+            positiveEvaluateList.add(new EvaluateDto.PositiveEvaluate() {
+                @Override
+                public EvaluateBadge getContent() {
+                    return GOOD_TIMECHECK;
+                }
+                @Override
+                public Long getCount() {
+                    return 0L;
+                }
+            });
+        }
+        if(!isInGOOD_TOGETHER) {
+            positiveEvaluateList.add(new EvaluateDto.PositiveEvaluate() {
+                @Override
+                public EvaluateBadge getContent() {
+                    return GOOD_TOGETHER;
+                }
+                @Override
+                public Long getCount() {
+                    return 0L;
+                }
+            });
+        }
+        if(!isInGOOD_RESPONSE) {
+            positiveEvaluateList.add(new EvaluateDto.PositiveEvaluate() {
+                @Override
+                public EvaluateBadge getContent() {
+                    return GOOD_RESPONSE;
+                }
+                @Override
+                public Long getCount() {
+                    return 0L;
+                }
+            });
+        }
+    }
+
+    public static void insertZeroValueInNegativeEvaluateArray(List<EvaluateDto.NegativeEvaluate> negativeEvaluateList) {
+        boolean isInBAD_RESPONSE = false;
+        boolean isInBAD_TIMECHECK = false;
+        boolean isInBAD_TOGETHER = false;
+
+        for(int i = 0; i < negativeEvaluateList.size(); i++) {
+            switch(negativeEvaluateList.get(i).getContent()) {
+                case BAD_RESPONSE :
+                    isInBAD_RESPONSE = true;
+                    break;
+                case BAD_TIMECHECK :
+                    isInBAD_TIMECHECK = true;
+                    break;
+                case BAD_TOGETHER :
+                    isInBAD_TOGETHER = true;
+                    break;
+            }
+        }
+
+        if(!isInBAD_RESPONSE) {
+            negativeEvaluateList.add(new EvaluateDto.NegativeEvaluate() {
+                @Override
+                public EvaluateBadge getContent() {
+                    return BAD_RESPONSE;
+                }
+                @Override
+                public Long getCount() {
+                    return 0L;
+                }
+            });
+        }
+        if(!isInBAD_TIMECHECK) {
+            negativeEvaluateList.add(new EvaluateDto.NegativeEvaluate() {
+                @Override
+                public EvaluateBadge getContent() {
+                    return BAD_TIMECHECK;
+                }
+                @Override
+                public Long getCount() {
+                    return 0L;
+                }
+            });
+        }
+        if(!isInBAD_TOGETHER) {
+            negativeEvaluateList.add(new EvaluateDto.NegativeEvaluate() {
+                @Override
+                public EvaluateBadge getContent() {
+                    return BAD_TOGETHER;
+                }
+                @Override
+                public Long getCount() {
+                    return 0L;
+                }
+            });
+        }
+    }
 }

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/EvaluateServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/EvaluateServiceImpl.java
@@ -1,5 +1,7 @@
 package com.zerobase.babdeusilbun.service.impl;
 
+import static com.zerobase.babdeusilbun.dto.EvaluateDto.insertZeroValueInNegativeEvaluateArray;
+import static com.zerobase.babdeusilbun.dto.EvaluateDto.insertZeroValueInPositiveEvaluateArray;
 import static com.zerobase.babdeusilbun.enums.MeetingStatus.*;
 import static com.zerobase.babdeusilbun.exception.ErrorCode.*;
 
@@ -39,6 +41,9 @@ public class EvaluateServiceImpl implements EvaluateService {
         userId);
     List<EvaluateDto.NegativeEvaluate> negativeEvaluateList = evaluateRepository.findNegativeEvaluatesByUserId(
         userId);
+
+    insertZeroValueInPositiveEvaluateArray(positiveEvaluateList);
+    insertZeroValueInNegativeEvaluateArray(negativeEvaluateList);
 
     EvaluateDto.MyEvaluates evaluates = EvaluateDto.MyEvaluates.builder()
         .positiveEvaluate(positiveEvaluateList).negativeEvaluate(negativeEvaluateList).build();

--- a/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/babdeusilbun/service/impl/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.zerobase.babdeusilbun.service.impl;
 
+import static com.zerobase.babdeusilbun.dto.EvaluateDto.insertZeroValueInPositiveEvaluateArray;
 import static com.zerobase.babdeusilbun.exception.ErrorCode.USER_NOT_FOUND;
 import static com.zerobase.babdeusilbun.util.ImageUtility.USER_IMAGE_FOLDER;
 
@@ -49,14 +50,16 @@ public class UserServiceImpl implements UserService {
     MyPage userPage = userRepository.findMyPageByUserId(userId)
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-    List<EvaluateDto.PositiveEvaluate> positiveEvaluate = evaluateRepository.findPositiveEvaluatesByUserId(userId);
+    List<EvaluateDto.PositiveEvaluate> positiveEvaluateList = evaluateRepository.findPositiveEvaluatesByUserId(userId);
+
+    insertZeroValueInPositiveEvaluateArray(positiveEvaluateList);
 
     Profile userProfile = Profile.builder()
             .nickname(userPage.getNickname())
             .image(userPage.getImage())
             .major(userPage.getMajor())
             .meetingCount(userPage.getMeetingCount())
-            .positiveEvaluate(positiveEvaluate)
+            .positiveEvaluate(positiveEvaluateList)
             .build();
 
     return userProfile;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 프론트엔드 측에서 배지의 개수가 0이여도 해당 배지 정보를 반환할 수 있도록 기능 수정을 요청하였습니다.

- 기존에는 해당 배지가 없으면 관련 정보를 가지고 있지 않았습니다.

**TO-BE**
- 긍정(부정)평가배지 배열에 특정 배지 정보가 없을 경우 count가 0인 상태로 배지 정보를 추가해주는 메서드를 생성하였습니다.



### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 