### PR TITLE
refactoring: Swagger RequestPart 부분들 컨트롤러에 직접 작성, securityItem() 빠진 그룹들 추가

### DIFF
--- a/src/main/java/com/zerobase/babdeusilbun/config/SwaggerConfig.java
+++ b/src/main/java/com/zerobase/babdeusilbun/config/SwaggerConfig.java
@@ -89,7 +89,11 @@ public class SwaggerConfig {
   public GroupedOpenApi entrepreneurs() {
     return GroupedOpenApi.builder()
         .group("03. 사업가 이용 가능 API")
-        .addOpenApiCustomizer(openApi -> filterPaths(openApi, ENTREPRENEUR_TAG))
+        .addOpenApiCustomizer(openApi -> {
+          filterPaths(openApi, ENTREPRENEUR_TAG);
+
+          openApi.addSecurityItem(securityRequirementList());
+        })
         .build();
   }
 
@@ -97,7 +101,11 @@ public class SwaggerConfig {
   public GroupedOpenApi user() {
     return GroupedOpenApi.builder()
         .group("02. 일반 이용자 이용 가능 API")
-        .addOpenApiCustomizer(openApi -> filterPaths(openApi, USER_TAG))
+        .addOpenApiCustomizer(openApi -> {
+          filterPaths(openApi, USER_TAG);
+
+          openApi.addSecurityItem(securityRequirementList());
+        })
         .build();
   }
 
@@ -114,7 +122,9 @@ public class SwaggerConfig {
     return GroupedOpenApi.builder()
         .group("00. 전체 API")
         .addOpenApiCustomizer(openApi ->
-            openApi.setTags(SETTING_TAGS))
+            openApi
+                .addSecurityItem(securityRequirementList())
+                .setTags(SETTING_TAGS))
         .build();
   }
 

--- a/src/main/java/com/zerobase/babdeusilbun/controller/inquery/UserInquiryController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/inquery/UserInquiryController.java
@@ -15,6 +15,7 @@ import com.zerobase.babdeusilbun.dto.InquiryDto.Response;
 import com.zerobase.babdeusilbun.dto.InquiryImageDto;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.InquiryService;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -57,7 +58,9 @@ public class UserInquiryController {
   @CreateInquirySwagger
   public ResponseEntity<Void> createInquiry(
       @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Parameter(description = "작성할 게시글의 제목과 내용")
       @Validated @RequestPart("request") InquiryDto.Request request,
+      @Parameter(description = "최대 3장, 10MB 이하")
       @RequestPart(value = "files", required = false) List<MultipartFile> images
   ) {
 

--- a/src/main/java/com/zerobase/babdeusilbun/controller/menu/EntrepreneurMenuController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/menu/EntrepreneurMenuController.java
@@ -9,6 +9,7 @@ import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 import com.zerobase.babdeusilbun.dto.MenuDto;
 import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.MenuService;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -34,7 +35,9 @@ public class EntrepreneurMenuController {
     public ResponseEntity<Void> updateMenu(
             @AuthenticationPrincipal CustomUserDetails entrepreneur,
             @PathVariable("menuId") Long menuId,
+            @Parameter(description = "10MB 이하의 변경할 이미지(없다면 입력X)")
             @RequestPart(value = "file", required = false) MultipartFile image,
+            @Parameter(description = "메뉴 수정사항")
             @RequestPart(value = "request") MenuDto.UpdateRequest request
     ) {
 

--- a/src/main/java/com/zerobase/babdeusilbun/controller/profile/EntrepreneurProfileController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/profile/EntrepreneurProfileController.java
@@ -10,6 +10,7 @@ import com.zerobase.babdeusilbun.security.dto.CustomUserDetails;
 import com.zerobase.babdeusilbun.service.EntrepreneurService;
 import com.zerobase.babdeusilbun.swagger.annotation.profile.EntrepreneurProfileSwagger.GetProfileSwagger;
 import com.zerobase.babdeusilbun.swagger.annotation.profile.EntrepreneurProfileSwagger.UpdateProfileSwagger;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -46,7 +47,9 @@ public class EntrepreneurProfileController {
   @UpdateProfileSwagger
   public ResponseEntity<Void> updateProfile(
       @AuthenticationPrincipal CustomUserDetails entrepreneur,
+      @Parameter(description = "10MB 이하의 변경할 이미지(없다면 입력X)")
       @RequestPart(value = "file", required = false) MultipartFile image,
+      @Parameter(description = "회원 정보 수정사항")
       @RequestPart("request") UpdateRequest request
   ) {
 

--- a/src/main/java/com/zerobase/babdeusilbun/controller/profile/UserProfileController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/profile/UserProfileController.java
@@ -17,6 +17,7 @@ import com.zerobase.babdeusilbun.swagger.annotation.profile.UserProfileSwagger.G
 import com.zerobase.babdeusilbun.swagger.annotation.profile.UserProfileSwagger.UpdateAccountSwagger;
 import com.zerobase.babdeusilbun.swagger.annotation.profile.UserProfileSwagger.UpdateAddressSwagger;
 import com.zerobase.babdeusilbun.swagger.annotation.profile.UserProfileSwagger.UpdateProfileSwagger;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -56,7 +57,9 @@ public class UserProfileController {
   @UpdateProfileSwagger
   public ResponseEntity<Void> updateProfile(
       @AuthenticationPrincipal CustomUserDetails user,
+      @Parameter(description = "10MB 이하의 변경할 이미지(없다면 입력X)")
       @RequestPart(value = "file", required = false) MultipartFile image,
+      @Parameter(description = "회원 정보 수정사항")
       @RequestPart(value = "request") UpdateRequest request) {
     UpdateRequest changeRequest = userService.updateProfile(user.getId(), image, request);
 

--- a/src/main/java/com/zerobase/babdeusilbun/controller/store/EntrepreneurStoreManagementController.java
+++ b/src/main/java/com/zerobase/babdeusilbun/controller/store/EntrepreneurStoreManagementController.java
@@ -31,6 +31,7 @@ import com.zerobase.babdeusilbun.swagger.annotation.store.EntrepreneurStoreManag
 import com.zerobase.babdeusilbun.swagger.annotation.store.EntrepreneurStoreManagementSwagger.EnrollToCategorySwagger;
 import com.zerobase.babdeusilbun.swagger.annotation.store.EntrepreneurStoreManagementSwagger.UpdateStoreImageInformationSwagger;
 import com.zerobase.babdeusilbun.swagger.annotation.store.EntrepreneurStoreManagementSwagger.UpdateStoreInformationSwagger;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -61,7 +62,9 @@ public class EntrepreneurStoreManagementController {
   @CreateStoreSwagger
   public ResponseEntity<IdResponse> createStore(
       @AuthenticationPrincipal CustomUserDetails entrepreneur,
+      @Parameter(description = "최대 3장, 10MB 이하")
       @RequestPart(value = "files", required = false) List<MultipartFile> images,
+      @Parameter(description = "등록할 상점 정보")
       @RequestPart(value = "request") CreateRequest request) {
     IdResponse storeId = storeService.createStore(entrepreneur.getId(), request);
 
@@ -83,7 +86,9 @@ public class EntrepreneurStoreManagementController {
   public ResponseEntity<Void> createMenu(
       @AuthenticationPrincipal CustomUserDetails entrepreneur,
       @PathVariable("storeId") Long storeId,
+      @Parameter(description = "10MB 이하의 이미지(없다면 입력X)")
       @RequestPart(value = "file", required = false) MultipartFile image,
+      @Parameter(description = "등록할 메뉴 정보")
       @RequestPart(value = "request") MenuDto.CreateRequest request) {
 
     MenuDto.CreateRequest result = menuService.createMenu(entrepreneur.getId(), storeId, image, request);
@@ -235,6 +240,7 @@ public class EntrepreneurStoreManagementController {
   public ResponseEntity<Void> enrollImagesToStore(
       @AuthenticationPrincipal CustomUserDetails entrepreneur,
       @PathVariable("storeId") Long storeId,
+      @Parameter(description = "기존에 등록된 이미지 포함 최대 3장, 10MB 이하")
       @RequestPart(value = "files", required = false) List<MultipartFile> images
   ) {
     int successCount = storeService.uploadImageToStore(entrepreneur.getId(), images, storeId);

--- a/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/inquery/UserInquirySwagger.java
+++ b/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/inquery/UserInquirySwagger.java
@@ -1,6 +1,5 @@
 package com.zerobase.babdeusilbun.swagger.annotation.inquery;
 
-import com.zerobase.babdeusilbun.dto.InquiryDto;
 import com.zerobase.babdeusilbun.dto.InquiryDto.Response;
 import com.zerobase.babdeusilbun.dto.InquiryImageDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,7 +9,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,7 +17,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.web.multipart.MultipartFile;
 
 public @interface UserInquirySwagger {
 
@@ -45,14 +42,6 @@ public @interface UserInquirySwagger {
   @Operation(
       summary = "문의 게시글 작성 api",
       description = "문의 게시글 작성")
-  @Parameter(
-      name = "files", description = "최대 3장, 10MB 이하",
-      content = @Content(mediaType = "multipart/form-data",
-      array = @ArraySchema(schema = @Schema(implementation = MultipartFile.class))))
-  @RequestBody(
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = InquiryDto.Request.class)),
-      description = "작성할 게시글의 제목과 내용")
   @ApiResponses(value = {
       @ApiResponse(
           responseCode = "201", description = "게시글 작성에 성공한 경우")

--- a/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/menu/EntrepreneurMenuSwagger.java
+++ b/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/menu/EntrepreneurMenuSwagger.java
@@ -1,13 +1,8 @@
 package com.zerobase.babdeusilbun.swagger.annotation.menu;
 
-import com.zerobase.babdeusilbun.dto.MenuDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,7 +11,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.web.multipart.MultipartFile;
 
 public @interface EntrepreneurMenuSwagger {
   @Target(ElementType.METHOD)
@@ -25,16 +19,7 @@ public @interface EntrepreneurMenuSwagger {
   @Operation(
       summary = "메뉴 수정 api",
       description = "상점에 등록했던 메뉴 정보 수정")
-  @Parameters(value = {
-      @Parameter(
-          name = "file", description = "10MB 이하의 변경할 이미지(없다면 입력X)",
-          content = @Content(mediaType = "multipart/form-data", schema = @Schema(implementation = MultipartFile.class))),
-      @Parameter(name = "menuId", description = "변경하려는 메뉴의 id", in = ParameterIn.PATH)
-  })
-  @RequestBody(
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = MenuDto.UpdateRequest.class)),
-      description = "메뉴 수정사항")
+  @Parameter(name = "menuId", description = "삭제하려는 메뉴의 id", in = ParameterIn.PATH)
   @ApiResponses(value = {
       @ApiResponse(
           responseCode = "200", description = "메뉴 정보 변경에 성공한 경우"),

--- a/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/profile/EntrepreneurProfileSwagger.java
+++ b/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/profile/EntrepreneurProfileSwagger.java
@@ -1,12 +1,9 @@
 package com.zerobase.babdeusilbun.swagger.annotation.profile;
 
 import com.zerobase.babdeusilbun.dto.EntrepreneurDto.MyPage;
-import com.zerobase.babdeusilbun.dto.EntrepreneurDto.UpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,7 +12,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.web.multipart.MultipartFile;
 
 public @interface EntrepreneurProfileSwagger {
   @Target(ElementType.METHOD)
@@ -38,13 +34,6 @@ public @interface EntrepreneurProfileSwagger {
   @Operation(
       summary = "회원 정보 수정 api",
       description = "로그인한 사업가 권한의 이용자 정보 수정")
-  @Parameter(
-      name = "file", description = "10MB 이하의 변경할 이미지(없다면 입력X)",
-      content = @Content(mediaType = "multipart/form-data", schema = @Schema(implementation = MultipartFile.class)))
-  @RequestBody(
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = UpdateRequest.class)),
-      description = "회원 정보 수정사항")
   @ApiResponses(value = {
       @ApiResponse(
           responseCode = "200", description = "회원 정보 수정에 성공한 경우"),

--- a/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/profile/UserProfileSwagger.java
+++ b/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/profile/UserProfileSwagger.java
@@ -4,9 +4,7 @@ import com.zerobase.babdeusilbun.dto.EvaluateDto.MyEvaluates;
 import com.zerobase.babdeusilbun.dto.UserDto.MyPage;
 import com.zerobase.babdeusilbun.dto.UserDto.UpdateAccount;
 import com.zerobase.babdeusilbun.dto.UserDto.UpdateAddress;
-import com.zerobase.babdeusilbun.dto.UserDto.UpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -18,7 +16,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.web.multipart.MultipartFile;
 
 public @interface UserProfileSwagger {
   @Target(ElementType.METHOD)
@@ -41,13 +38,6 @@ public @interface UserProfileSwagger {
   @Operation(
       summary = "회원 정보 수정 api",
       description = "로그인한 일반 이용자 권한의 이용자 정보 수정")
-  @Parameter(
-      name = "file", description = "10MB 이하의 변경할 이미지(없다면 입력X)",
-      content = @Content(mediaType = "multipart/form-data", schema = @Schema(implementation = MultipartFile.class)))
-  @RequestBody(
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = UpdateRequest.class)),
-      description = "회원 정보 수정사항")
   @ApiResponses(value = {
       @ApiResponse(
           responseCode = "200", description = "회원 정보 수정에 성공한 경우"),

--- a/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/store/EntrepreneurStoreManagementSwagger.java
+++ b/src/main/java/com/zerobase/babdeusilbun/swagger/annotation/store/EntrepreneurStoreManagementSwagger.java
@@ -2,9 +2,7 @@ package com.zerobase.babdeusilbun.swagger.annotation.store;
 
 import com.zerobase.babdeusilbun.dto.CategoryDto.IdsRequest;
 import com.zerobase.babdeusilbun.dto.HolidayDto.HolidaysRequest;
-import com.zerobase.babdeusilbun.dto.MenuDto;
 import com.zerobase.babdeusilbun.dto.SchoolDto;
-import com.zerobase.babdeusilbun.dto.StoreDto.CreateRequest;
 import com.zerobase.babdeusilbun.dto.StoreDto.IdResponse;
 import com.zerobase.babdeusilbun.dto.StoreDto.UpdateRequest;
 import com.zerobase.babdeusilbun.dto.StoreImageDto;
@@ -12,7 +10,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -24,7 +21,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.web.multipart.MultipartFile;
 
 public @interface EntrepreneurStoreManagementSwagger {
   @Target(ElementType.METHOD)
@@ -33,14 +29,6 @@ public @interface EntrepreneurStoreManagementSwagger {
   @Operation(
       summary = "상점 등록 api",
       description = "사업가가 새로 상점을 등록")
-  @Parameter(
-      name = "files", description = "최대 3장, 10MB 이하",
-      content = @Content(mediaType = "multipart/form-data",
-          array = @ArraySchema(schema = @Schema(implementation = MultipartFile.class))))
-  @RequestBody(
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = CreateRequest.class)),
-      description = "등록할 상점 정보")
   @ApiResponses(value = {
       @ApiResponse(
           responseCode = "201", description = "상점 등록에 성공한 경우",
@@ -58,16 +46,7 @@ public @interface EntrepreneurStoreManagementSwagger {
   @Operation(
       summary = "메뉴 등록 api",
       description = "사업가가 자신의 상점에 새로운 메뉴를 등록")
-  @Parameters(value = {
-      @Parameter(
-          name = "file", description = "10MB 이하의 이미지(없다면 입력X)",
-          content = @Content(mediaType = "multipart/form-data", schema = @Schema(implementation = MultipartFile.class))),
-      @Parameter(name = "storeId", description = "메뉴를 등록할 상점의 id", in = ParameterIn.PATH)
-  })
-  @RequestBody(
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = MenuDto.CreateRequest.class)),
-      description = "등록할 메뉴 정보")
+  @Parameter(name = "storeId", description = "메뉴를 등록할 상점의 id", in = ParameterIn.PATH)
   @ApiResponses(value = {
       @ApiResponse(
           responseCode = "201", description = "메뉴 등록에 성공한 경우"),
@@ -233,13 +212,7 @@ public @interface EntrepreneurStoreManagementSwagger {
   @Operation(
       summary = "상점 이미지 등록 api",
       description = "상점에 이미지 등록(단, 기존 상점 이미지와 합하여 입력된 이미지 개수가 3장을 넘어갈 경우 등록 불가)")
-  @Parameters(value = {
-      @Parameter(
-          name = "files", description = "기존에 등록된 이미지 포함 최대 3장, 10MB 이하",
-          content = @Content(mediaType = "multipart/form-data",
-              array = @ArraySchema(schema = @Schema(implementation = MultipartFile.class)))),
-      @Parameter(name = "storeId", description = "이미지를 등록할 상점의 id", in = ParameterIn.PATH)
-  })
+  @Parameter(name = "storeId", description = "이미지를 등록할 상점의 id", in = ParameterIn.PATH)
   @ApiResponses(value = {
       @ApiResponse(
           responseCode = "200", description = "이미지 등록에 성공한 경우"),


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- header 전달값이 필요한 그룹들에 작성이 안되어 헤더값이 전달되지 않았습니다.
- RequestPart가 Swagger 상에서 파라미터로 입력되면 컨트롤러와 입력 파트가 분리되어 나타나는 현상이 있었습니다.

**TO-BE**
- Controller에 RequestPart의 description은 따로 기술했습니다.
- header 전달값이 필요한 Swagger 그룹들에 헤더값을 전달하게 하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 